### PR TITLE
Code tidy

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CompetitorTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CompetitorTests.cs
@@ -52,6 +52,7 @@ namespace TournamentManagement.Domain.UnitTests
 		{
 			var tournamentId = new TournamentId();
 			var eventEntryId = new EventEntryId();
+			var expectedPlayerCount = numberOfPlayers == 2 ? 1 : 2;
 			var playersNames = new List<string>();
 			for (int i = 0; i < numberOfPlayers; i++)
 			{
@@ -63,7 +64,7 @@ namespace TournamentManagement.Domain.UnitTests
 
 			act.Should()
 				.Throw<Exception>()
-				.WithMessage("Wrong number of players for this event type");
+				.WithMessage($"Competitor for {eventType} event must have {expectedPlayerCount} players");
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CompetitorTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CompetitorTests.cs
@@ -11,14 +11,15 @@ namespace TournamentManagement.Domain.UnitTests
 		public void CanUseFactoryMethodToCreateCompetitorForASinglesEventAndItIsCreatedCorrectly()
 		{
 			var tournamentId = new TournamentId();
-			var eventEntryId = Guid.NewGuid();
-			var competitor = Competitor.Create(tournamentId, EventType.MensSingles, eventEntryId, 1,
-				new List<string>() { "Steve Serve" });
+			var eventEntryId = new EventEntryId();
+			var seeding = new Seeding(1);
+			var competitor = Competitor.Create(tournamentId, EventType.MensSingles, eventEntryId,
+				seeding, new List<string>() { "Steve Serve" });
 
 			competitor.Id.Id.Should().NotBe(Guid.Empty);
 			competitor.TournamentId.Should().Be(tournamentId);
 			competitor.EventType.Should().Be(EventType.MensSingles);
-			competitor.Seeding.Should().Be(1);
+			competitor.Seeding.Should().Be(seeding);
 			competitor.PlayerNames.Count.Should().Be(1);
 			competitor.PlayerNames[0].Should().Be("Steve Serve");
 		}
@@ -27,33 +28,18 @@ namespace TournamentManagement.Domain.UnitTests
 		public void CanUseFactoryMethodToCreateCompetitorForADoublesEventAndItIsCreatedCorrectly()
 		{
 			var tournamentId = new TournamentId();
-			var eventEntryId = Guid.NewGuid();
-			var competitor = Competitor.Create(tournamentId, EventType.MensDoubles, eventEntryId, 1,
-				new List<string>() { "Steve Serve", "Vernon Volley" });
+			var eventEntryId = new EventEntryId();
+			var seeding = new Seeding(1);
+			var competitor = Competitor.Create(tournamentId, EventType.MensDoubles, eventEntryId,
+				seeding, new List<string>() { "Steve Serve", "Vernon Volley" });
 
 			competitor.Id.Id.Should().NotBe(Guid.Empty);
 			competitor.TournamentId.Should().Be(tournamentId);
 			competitor.EventType.Should().Be(EventType.MensDoubles);
-			competitor.Seeding.Should().Be(1);
+			competitor.Seeding.Should().Be(seeding);
 			competitor.PlayerNames.Count.Should().Be(2);
 			competitor.PlayerNames[0].Should().Be("Steve Serve");
 			competitor.PlayerNames[1].Should().Be("Vernon Volley");
-		}
-
-		[Theory]
-		[InlineData(-1)]
-		[InlineData(33)]
-		public void CannotCreateCompetitorWithInvalidSeeding(int seeding)
-		{
-			var tournamentId = new TournamentId();
-			var eventEntryId = Guid.NewGuid();
-			
-			Action act = () => Competitor.Create(tournamentId, EventType.MensSingles, eventEntryId, seeding,
-				new List<string>() { "Steve Serve" });
-
-			act.Should()
-				.Throw<Exception>()
-				.WithMessage($"Value {seeding} must be between 0 and 32 (Parameter 'seeding')");
 		}
 
 		[Theory]
@@ -65,14 +51,14 @@ namespace TournamentManagement.Domain.UnitTests
 		public void CannotCreateCompetitorWithWrongNumberOfPlayers(EventType eventType, int numberOfPlayers)
 		{
 			var tournamentId = new TournamentId();
-			var eventEntryId = Guid.NewGuid();
+			var eventEntryId = new EventEntryId();
 			var playersNames = new List<string>();
 			for (int i = 0; i < numberOfPlayers; i++)
 			{
 				playersNames.Add("Player");
 			}
 
-			Action act = () => Competitor.Create(tournamentId, eventType, eventEntryId, 1,
+			Action act = () => Competitor.Create(tournamentId, eventType, eventEntryId, new Seeding(1),
 				playersNames);
 
 			act.Should()

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/EventTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/EventTests.cs
@@ -64,5 +64,20 @@ namespace TournamentManagement.Domain.UnitTests
 
 			tennisEvent.IsCompleted.Should().BeTrue();
 		}
+
+		[Fact]
+		public void CannotUpdateAnventThatIsCompleted()
+		{
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
+				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
+			tennisEvent.MarkEventCompleted();
+
+			Action act = () => tennisEvent.UpdateDetails(EventType.WomensSingles, 64, 16,
+				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
+
+			act.Should()
+				.Throw<Exception>()
+				.WithMessage("Cannot update the details of an event that is completed");
+		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/RoundTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/RoundTests.cs
@@ -44,7 +44,7 @@ namespace TournamentManagement.Domain.UnitTests
 
 			act.Should()
 				.Throw<ArgumentException>()
-				.WithMessage($"{competitorCount} is not one of the allowed values (Parameter 'playerCount')");
+				.WithMessage($"{competitorCount} is not one of the allowed values (Parameter 'competitorCount')");
 		}
 
 		[Theory]

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/SeedingTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/SeedingTests.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using System;
+using Xunit;
+
+
+namespace TournamentManagement.Domain.UnitTests
+{
+	public class SeedingTests
+	{
+		[Theory]
+		[InlineData(1)]
+		[InlineData(32)]
+		public void CanCreateASeeding(int seed)
+		{
+			var seeding = new Seeding(seed);
+
+			seeding.Seed.Should().Be(seed);
+		}
+
+		[Theory]
+		[InlineData(0)]
+		[InlineData(33)]
+		public void CannotCreateASeedingWithSeedValueOutOfRange(int seed)
+		{
+			Action act = () => new Seeding(seed);
+
+			act.Should()
+				.Throw<ArgumentException>()
+				.WithMessage($"Value {seed} must be between 1 and 32 (Parameter 'seed')");
+		}
+
+		[Fact]
+		public void SeedEqualityShouldWork()
+		{
+			var seeding1 = new Seeding(1);
+			var seeding2 = new Seeding(1);
+			var seeding3 = new Seeding(2);
+
+			(seeding1 == seeding2).Should().BeTrue();
+			(seeding1 == seeding3).Should().BeFalse();
+		}
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Domain/Competitor.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Competitor.cs
@@ -7,10 +7,10 @@ namespace TournamentManagement.Domain
 {
 	public class Competitor : Entity<CompetitorId>
 	{
+		public EventEntryId EventEntryId { get; private set; }
 		public TournamentId TournamentId { get; private set; }
 		public EventType EventType { get; private set; }
-		public Guid EventEntryId { get; private set; }
-		public int Seeding { get; private set; }
+		public Seeding Seeding { get; private set; }
 		public ReadOnlyCollection<string> PlayerNames { get; private set; }
 
 		private IList<string> _playersNames { get; set; }
@@ -22,9 +22,8 @@ namespace TournamentManagement.Domain
 		}
 
 		public static Competitor Create(TournamentId tournamentId, EventType eventType,
-			Guid eventEntryId, int seeding, ICollection<string> playersNames)
+			EventEntryId eventEntryId, Seeding seeding, ICollection<string> playersNames)
 		{
-			Guard.ForIntegerOutOfRange(seeding, 0, 32, "seeding");
 			GuardAgainstWrongNumberOfPlayers(eventType, playersNames.Count);
 
 			var competitor = new Competitor(new CompetitorId(), playersNames)

--- a/src/TournamentManagement/TournamentManagement.Domain/Competitor.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Competitor.cs
@@ -42,7 +42,7 @@ namespace TournamentManagement.Domain
 			var expectedPlayerCount = Event.IsSinglesEvent(eventType) ? 1 : 2;
 			if (playerCount != expectedPlayerCount)
 			{
-				throw new Exception("Wrong number of players for this event type");
+				throw new Exception($"Competitor for {eventType} event must have {expectedPlayerCount} players");
 			}
 		}
 	}

--- a/src/TournamentManagement/TournamentManagement.Domain/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Event.cs
@@ -11,7 +11,6 @@ namespace TournamentManagement.Domain
 		public EventSize EventSize { get; private set; }
 		public bool IsCompleted { get; private set; }
 
-
 		private Event(EventId id) : base(id)
 		{
 		}
@@ -30,6 +29,7 @@ namespace TournamentManagement.Domain
 
 		public void UpdateDetails(EventType eventType, int entrantsLimit, int numberOfSeeds, MatchFormat matchFormat)
 		{
+			GuardAgainstUpdatingCompletedEvent();
 			SetAttributeDetails(eventType, entrantsLimit, numberOfSeeds, matchFormat);
 		}
 
@@ -45,6 +45,14 @@ namespace TournamentManagement.Domain
 			MatchFormat = matchFormat;
 			SinglesEvent = IsSinglesEvent(eventType);
 			EventSize = new EventSize(entrantsLimit, numberOfSeeds);
+		}
+
+		private void GuardAgainstUpdatingCompletedEvent()
+		{
+			if (IsCompleted)
+			{
+				throw new Exception("Cannot update the details of an event that is completed");
+			}
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain/EventEntry.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/EventEntry.cs
@@ -46,6 +46,17 @@ namespace TournamentManagement.Domain
 			return entry;
 		}
 
+		private static EventEntry CreateEntry(TournamentId tournamentId, EventType eventType)
+		{
+			var entry = new EventEntry(new EventEntryId())
+			{
+				TournamentId = new TournamentId(tournamentId.Id),
+				EventType = eventType,
+			};
+
+			return entry;
+		}
+
 		private static void GuardIsSinglesEvent(EventType eventType)
 		{
 			if (!Event.IsSinglesEvent(eventType))
@@ -60,17 +71,6 @@ namespace TournamentManagement.Domain
 			{
 				throw new ArgumentException($"{eventType} is not a doubles event");
 			}
-		}
-
-		private static EventEntry CreateEntry(TournamentId tournamentId, EventType eventType)
-		{
-			var entry = new EventEntry(new EventEntryId())
-			{
-				TournamentId = new TournamentId(tournamentId.Id),
-				EventType = eventType,
-			};
-
-			return entry;
 		}
 
 		private static void GuardForValidPlayerGender(EventType eventtype, IEnumerable<Player> players)

--- a/src/TournamentManagement/TournamentManagement.Domain/EventSize.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/EventSize.cs
@@ -1,5 +1,4 @@
 ﻿using DomainDesign.Common;
-using System;
 
 namespace TournamentManagement.Domain
 {
@@ -17,8 +16,8 @@ namespace TournamentManagement.Domain
 
 		public EventSize(int entrantsLimit, int numberOfSeeds)
 		{
-			Guard.ForValueNotInSetOfAllowedValues(numberOfSeeds, AllowedNumberOfSeeds, "numberOfSeeds");
-			Guard.ForIntegerOutOfRange(entrantsLimit, numberOfSeeds, MaxNumberOfEntrants, "entrantsLimit");
+			Guard.ForValueNotInSetOfAllowedValues(numberOfSeeds, AllowedNumberOfSeeds, nameof(numberOfSeeds));
+			Guard.ForIntegerOutOfRange(entrantsLimit, numberOfSeeds, MaxNumberOfEntrants, nameof(entrantsLimit));
 
 			EntrantsLimit = entrantsLimit;
 			NumberOfSeeds = numberOfSeeds;

--- a/src/TournamentManagement/TournamentManagement.Domain/Player.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Player.cs
@@ -19,9 +19,9 @@ namespace TournamentManagement.Domain
 
 		public static Player Create(string name, ushort singlesRank, ushort doublesRank, Gender gender)
 		{
-			Guard.ForNullOrEmptyString(name, "Name");
-			GuardForRankInRange(singlesRank, "Singles Rank");
-			GuardForRankInRange(doublesRank, "Doubles Rank");
+			Guard.ForNullOrEmptyString(name, nameof(name));
+			GuardForRankInRange(singlesRank, nameof(singlesRank));
+			GuardForRankInRange(doublesRank, nameof(doublesRank));
 
 			var player = new Player(Guid.NewGuid())
 			{

--- a/src/TournamentManagement/TournamentManagement.Domain/Round.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Round.cs
@@ -19,8 +19,8 @@ namespace TournamentManagement.Domain
 		public static Round Create(TournamentId tournamentId, EventType eventType,
 			int roundNumber, int competitorCount)
 		{
-			Guard.ForIntegerOutOfRange(roundNumber, 1, 7, "roundNumber");
-			Guard.ForValueNotInSetOfAllowedValues(competitorCount, AllowedCompetitorCount, "playerCount");
+			Guard.ForIntegerOutOfRange(roundNumber, 1, 7, nameof(roundNumber));
+			Guard.ForValueNotInSetOfAllowedValues(competitorCount, AllowedCompetitorCount, nameof(competitorCount));
 
 			var round = new Round(new RoundId())
 			{

--- a/src/TournamentManagement/TournamentManagement.Domain/Seeding.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Seeding.cs
@@ -1,0 +1,15 @@
+﻿using DomainDesign.Common;
+
+namespace TournamentManagement.Domain
+{
+	public class Seeding : ValueObject<Seeding>
+	{
+		public int Seed { get; }
+
+		public Seeding(int seed)
+		{
+			Guard.ForIntegerOutOfRange(seed, 1, 32, nameof(seed));
+			Seed = seed;
+		}
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Domain/SetScore.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/SetScore.cs
@@ -9,8 +9,8 @@ namespace TournamentManagement.Domain
 
 		public SetScore(int gamesOne, int gamesTwo)
 		{
-			Guard.ForIntegerOutOfRange(gamesOne, 0, 99, "gamesOne");
-			Guard.ForIntegerOutOfRange(gamesTwo, 0, 99, "gamesTwo");
+			Guard.ForIntegerOutOfRange(gamesOne, 0, 99, nameof(gamesOne));
+			Guard.ForIntegerOutOfRange(gamesTwo, 0, 99, nameof(gamesTwo));
 
 			GamesOne = gamesOne;
 			GamesTwo = gamesTwo;

--- a/src/TournamentManagement/TournamentManagement.Domain/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Tournament.cs
@@ -29,7 +29,7 @@ namespace TournamentManagement.Domain
 
 		public static Tournament Create(string title, TournamentLevel level, DateTime startDate, DateTime endDate)
 		{
-			Guard.ForNullOrEmptyString(title, "title");
+			Guard.ForNullOrEmptyString(title, nameof(title));
 
 			var tournament = new Tournament(new TournamentId())
 			{


### PR DESCRIPTION
Use Value Objects for EventEntryId and Seeding on Competitor
Improve exception text when wrong number of players used for a competitor
Should not be able to update the details of a completed Event
Use nameof() rather than string literals when validating parameters
Reorder methods in EventEntry