### PR TITLE
Player, Venue, and Court entities will have their IDs assigned in other Bounded Contexts

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CourtTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CourtTests.cs
@@ -9,9 +9,10 @@ namespace TournamentManagement.Domain.UnitTests
 		[Fact]
 		public void CanUseFactoryMethodToCreateCourtAndItIsCreatedCorrectly()
 		{
-			var court = Court.Create("Centre Court", 14979);
+			var courtId = new CourtId();
+			var court = Court.Create(courtId, "Centre Court", 14979);
 
-			court.Id.Id.Should().NotBe(Guid.Empty);
+			court.Id.Should().Be(courtId);
 			court.Name.Should().Be("Centre Court");
 			court.Capacity.Should().Be(14979);
 		}
@@ -21,7 +22,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData("")]
 		public void CannotCreateACourtWithEmptyName(string name)
 		{
-			Action act = () => Court.Create(name, 100);
+			Action act = () => Court.Create(new CourtId(), name, 100);
 
 			act.Should()
 				.Throw<ArgumentException>()
@@ -33,7 +34,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData(25000)]
 		public void CanCreateACourtWithCapacityValuesAtTheLimitsOfTheValidRange(int capacity)
 		{
-			var court = Court.Create("Centre Court", capacity);
+			var court = Court.Create(new CourtId(), "Centre Court", capacity);
 
 			court.Name.Should().Be("Centre Court");
 			court.Capacity.Should().Be(capacity);
@@ -44,7 +45,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData(25001)]
 		public void CannotCreateCourtWithCapacityValuesOutsideTheValidRange(int capacity)
 		{
-			Action act = () => Court.Create("Centre Court", capacity);
+			Action act = () => Court.Create(new CourtId(), "Centre Court", capacity);
 
 			act.Should()
 				.Throw<ArgumentException>();
@@ -53,7 +54,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[Fact]
 		public void CanRenameACourt()
 		{
-			var court = Court.Create("Centre Court", 14979);
+			var court = Court.Create(new CourtId(), "Centre Court", 14979);
 
 			court.RenameCourt("Murray Court");
 
@@ -63,7 +64,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[Fact]
 		public void CanUpdateTheCapacityOfACourt()
 		{
-			var court = Court.Create("Court 4", 100);
+			var court = Court.Create(new CourtId(), "Court 4", 100);
 
 			court.UpdateCapacity(200);
 
@@ -75,7 +76,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData("")]
 		public void CannotRenameACourtWithEmptyName(string newName)
 		{
-			var court = Court.Create("Court 4", 100);
+			var court = Court.Create(new CourtId(), "Court 4", 100);
 
 			Action act = () => court.RenameCourt(newName);
 
@@ -89,7 +90,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData(25001)]
 		public void CannotUpdateCapacityWithValueOutsideTheValidRange(int capacity)
 		{
-			var court = Court.Create("Court 4", 100);
+			var court = Court.Create(new CourtId(), "Court 4", 100);
 
 			Action act = () => court.UpdateCapacity(capacity);
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/EventEntryTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/EventEntryTests.cs
@@ -12,7 +12,8 @@ namespace TournamentManagement.Domain.UnitTests
 		public void CanUseFactoryMethodToCreateEntryToSinglesEvent(EventType eventType, Gender gender)
 		{
 			var tournamentId = new TournamentId();
-			var player = Player.Create("Steve Server", 20, 100, gender);
+			var playerId = new PlayerId();
+			var player = Player.Create(playerId, "Steve Server", 20, 100, gender);
 
 			var entry = EventEntry.CreateSinglesEventEntry(tournamentId, eventType, player);
 
@@ -31,8 +32,8 @@ namespace TournamentManagement.Domain.UnitTests
 			Gender genderOne, Gender genderTwo)
 		{
 			var tournamentId = new TournamentId();
-			var playerOne = Player.Create("Steve Server", 20, 100, genderOne);
-			var playerTwo = Player.Create("Gary Groundstroke", 30, 50, genderTwo);
+			var playerOne = Player.Create(new PlayerId(), "Steve Server", 20, 100, genderOne);
+			var playerTwo = Player.Create(new PlayerId(), "Gary Groundstroke", 30, 50, genderTwo);
 
 			var entry = EventEntry.CreateDoublesEventEntry(tournamentId, eventType, playerOne, playerTwo);
 
@@ -49,8 +50,8 @@ namespace TournamentManagement.Domain.UnitTests
 		public void CannotCreateSinglesEntryForADoublesEventType(EventType eventType)
 		{
 			var tournamentId = new TournamentId();
-			var playerOne = Player.Create("Steve Server", 20, 100, Gender.Male);
-			var playerTwo = Player.Create("Gary Groundstroke", 30, 50, Gender.Male);
+			var playerOne = Player.Create(new PlayerId(), "Steve Server", 20, 100, Gender.Male);
+			var playerTwo = Player.Create(new PlayerId(), "Gary Groundstroke", 30, 50, Gender.Male);
 
 			Action act = () => EventEntry.CreateDoublesEventEntry(tournamentId, eventType, playerOne, playerTwo);
 
@@ -66,7 +67,7 @@ namespace TournamentManagement.Domain.UnitTests
 		public void CannotCreateDoublesEntryToSinglesEvent(EventType eventType)
 		{
 			var tournamentId = new TournamentId();
-			var player = Player.Create("Steve Server", 20, 100, Gender.Male);
+			var player = Player.Create(new PlayerId(), "Steve Server", 20, 100, Gender.Male);
 
 			Action act = () => EventEntry.CreateSinglesEventEntry(tournamentId, eventType, player);
 
@@ -81,7 +82,7 @@ namespace TournamentManagement.Domain.UnitTests
 		public void IfGenderDoesNotMatchSinglesEventThenExceptionIsThrown(EventType eventType, Gender gender)
 		{
 			var tournamentId = new TournamentId();
-			var player = Player.Create("Steve Server", 20, 100, gender);
+			var player = Player.Create(new PlayerId(), "Steve Server", 20, 100, gender);
 
 			Action act = () => EventEntry.CreateSinglesEventEntry(tournamentId, eventType, player);
 
@@ -98,8 +99,8 @@ namespace TournamentManagement.Domain.UnitTests
 			Gender genderOne, Gender genderTwo)
 		{
 			var tournamentId = new TournamentId();
-			var playerOne = Player.Create("Steve Server", 20, 100, genderOne);
-			var playerTwo = Player.Create("Gary Groundstroke", 30, 50, genderTwo);
+			var playerOne = Player.Create(new PlayerId(), "Steve Server", 20, 100, genderOne);
+			var playerTwo = Player.Create(new PlayerId(), "Gary Groundstroke", 30, 50, genderTwo);
 
 			Action act = () => EventEntry.CreateDoublesEventEntry(tournamentId, eventType, playerOne, playerTwo);
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/PlayerTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/PlayerTests.cs
@@ -9,9 +9,10 @@ namespace TournamentManagement.Domain.UnitTests
 		[Fact]
 		public void CanUseFactoryMethodToCreatePlayerAndItIsCreatedCorrectly()
 		{
-			var player = Player.Create("Steve Serve", 10, 200, Gender.Male);
+			var playerId = new PlayerId();
+			var player = Player.Create(playerId, "Steve Serve", 10, 200, Gender.Male);
 
-			player.Id.Id.Should().NotBe(Guid.Empty);
+			player.Id.Should().Be(playerId);
 			player.Name.Should().Be("Steve Serve");
 			player.SinglesRank.Should().Be(10);
 			player.DoublesRank.Should().Be(200);
@@ -23,7 +24,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData("")]
 		public void CannotCreateAPlayerWithEmptyName(string name)
 		{
-			Action act = () => Player.Create(name, 100, 200, Gender.Female);
+			Action act = () => Player.Create(new PlayerId(), name, 100, 200, Gender.Female);
 
 			act.Should()
 				.Throw<ArgumentException>()
@@ -35,7 +36,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData(9999)]
 		public void CanCreateAPlayerWithRankValuesAtTheLimitsOfTheValidRange(ushort rank)
 		{
-			var player = Player.Create("Steve Serve", rank, rank, Gender.Male);
+			var player = Player.Create(new PlayerId(), "Steve Serve", rank, rank, Gender.Male);
 
 			player.SinglesRank.Should().Be(rank);
 			player.DoublesRank.Should().Be(rank);
@@ -48,7 +49,8 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData(100, 10000)]
 		public void CanCreatePlayerWithRankValuesOutsideTheValidRange(ushort singlesRank, ushort doublesRank)
 		{
-			Action act = () => Player.Create("Steve Serve", singlesRank, doublesRank, Gender.Female);
+			Action act = () => Player.Create(new PlayerId(), "Steve Serve", singlesRank, doublesRank,
+				Gender.Female);
 
 			act.Should()
 				.Throw<ArgumentException>();

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/VenueTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/VenueTests.cs
@@ -40,9 +40,9 @@ namespace TournamentManagement.Domain.UnitTests
 		{
 			var venue = Venue.Create(new VenueId(), "Flushing Meadows", Surface.Hard);
 
-			venue.AddCourt(Court.Create("Arthur Ashe", 23771));
-			venue.AddCourt(Court.Create("Louis Armstrong", 14053));
-			venue.AddCourt(Court.Create("Grandstand", 8125));
+			venue.AddCourt(Court.Create(new CourtId(), "Arthur Ashe", 23771));
+			venue.AddCourt(Court.Create(new CourtId(), "Louis Armstrong", 14053));
+			venue.AddCourt(Court.Create(new CourtId(), "Grandstand", 8125));
 
 			venue.Courts.Count.Should().Be(3);
 			var court = venue.Courts.First(c => c.Name == "Louis Armstrong");
@@ -53,10 +53,10 @@ namespace TournamentManagement.Domain.UnitTests
 		public void CannotAddCourtsWithTheSameNameToAVenue()
 		{
 			var venue = Venue.Create(new VenueId(), "Flushing Meadows", Surface.Hard);
-			venue.AddCourt(Court.Create("Arthur Ashe", 23771));
+			venue.AddCourt(Court.Create(new CourtId(), "Arthur Ashe", 23771));
 			venue.Courts.Count.Should().Be(1);
 
-			Action act = () => venue.AddCourt(Court.Create("Arthur Ashe", 100));
+			Action act = () => venue.AddCourt(Court.Create(new CourtId(), "Arthur Ashe", 100));
 
 			act.Should()
 				.Throw<Exception>()
@@ -68,9 +68,9 @@ namespace TournamentManagement.Domain.UnitTests
 		{
 			var venue = Venue.Create(new VenueId(), "Flushing Meadows", Surface.Hard);
 
-			venue.AddCourt(Court.Create("Arthur Ashe", 23771));
-			venue.AddCourt(Court.Create("Louis Armstrong", 14053));
-			venue.AddCourt(Court.Create("Grandstand", 8125));
+			venue.AddCourt(Court.Create(new CourtId(), "Arthur Ashe", 23771));
+			venue.AddCourt(Court.Create(new CourtId(), "Louis Armstrong", 14053));
+			venue.AddCourt(Court.Create(new CourtId(), "Grandstand", 8125));
 			venue.Courts.Count.Should().Be(3);
 			var court = venue.Courts.First(c => c.Name == "Louis Armstrong");
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/VenueTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/VenueTests.cs
@@ -14,9 +14,10 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData(Surface.Carpet)]
 		public void CanUseFactoryMethodToCreateVenueAndItIsCreatedCorrectly(Surface expectedSurface)
 		{
-			var venue = Venue.Create("Flushing Meadows", expectedSurface);
+			var venueId = new VenueId();
+			var venue = Venue.Create(venueId, "Flushing Meadows", expectedSurface);
 
-			venue.Id.Id.Should().NotBe(Guid.Empty);
+			venue.Id.Should().Be(venueId);
 			venue.Name.Should().Be("Flushing Meadows");
 			venue.Surface.Should().Be(expectedSurface);
 			venue.Courts.Count.Should().Be(0);
@@ -27,7 +28,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[InlineData("")]
 		public void CannotCreateAVenueWithEmptyName(string name)
 		{
-			Action act = () => Venue.Create(name, Surface.Hard);
+			Action act = () => Venue.Create(new VenueId(), name, Surface.Hard);
 
 			act.Should()
 				.Throw<ArgumentException>()
@@ -37,7 +38,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[Fact]
 		public void CanAddCourtsToAVenue()
 		{
-			var venue = Venue.Create("Flushing Meadows", Surface.Hard);
+			var venue = Venue.Create(new VenueId(), "Flushing Meadows", Surface.Hard);
 
 			venue.AddCourt(Court.Create("Arthur Ashe", 23771));
 			venue.AddCourt(Court.Create("Louis Armstrong", 14053));
@@ -51,7 +52,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[Fact]
 		public void CannotAddCourtsWithTheSameNameToAVenue()
 		{
-			var venue = Venue.Create("Flushing Meadows", Surface.Hard);
+			var venue = Venue.Create(new VenueId(), "Flushing Meadows", Surface.Hard);
 			venue.AddCourt(Court.Create("Arthur Ashe", 23771));
 			venue.Courts.Count.Should().Be(1);
 
@@ -65,7 +66,7 @@ namespace TournamentManagement.Domain.UnitTests
 		[Fact]
 		public void CanRemoveCourtsFromAVenue()
 		{
-			var venue = Venue.Create("Flushing Meadows", Surface.Hard);
+			var venue = Venue.Create(new VenueId(), "Flushing Meadows", Surface.Hard);
 
 			venue.AddCourt(Court.Create("Arthur Ashe", 23771));
 			venue.AddCourt(Court.Create("Louis Armstrong", 14053));

--- a/src/TournamentManagement/TournamentManagement.Domain/Court.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Court.cs
@@ -14,12 +14,12 @@ namespace TournamentManagement.Domain
 		{
 		}
 
-		public static Court Create(string name, int capacity)
+		public static Court Create(CourtId id, string name, int capacity)
 		{
 			Guard.AgainstNullOrEmptyString(name, nameof(name));
 			Guard.AgainstIntegerOutOfRange(capacity, MinCapacity, MaxCapacity, nameof(capacity));
 
-			var court = new Court(new CourtId())
+			var court = new Court(id)
 			{
 				Name = name,
 				Capacity = capacity

--- a/src/TournamentManagement/TournamentManagement.Domain/Player.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Player.cs
@@ -17,13 +17,14 @@ namespace TournamentManagement.Domain
 		{
 		}
 
-		public static Player Create(string name, ushort singlesRank, ushort doublesRank, Gender gender)
+		public static Player Create(PlayerId id, string name, ushort singlesRank,
+			ushort doublesRank, Gender gender)
 		{
 			Guard.AgainstNullOrEmptyString(name, nameof(name));
 			GuardAgainstRankOutOfRange(singlesRank, nameof(singlesRank));
 			GuardAgainstRankOutOfRange(doublesRank, nameof(doublesRank));
 
-			var player = new Player(new PlayerId())
+			var player = new Player(id)
 			{
 				Name = name,
 				SinglesRank = singlesRank,

--- a/src/TournamentManagement/TournamentManagement.Domain/Venue.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Venue.cs
@@ -20,11 +20,11 @@ namespace TournamentManagement.Domain
 			Courts = new ReadOnlyCollection<Court>(_courts);
 		}
 
-		public static Venue Create(string name, Surface surface)
+		public static Venue Create(VenueId id, string name, Surface surface)
 		{
 			Guard.AgainstNullOrEmptyString(name, nameof(name));
 
-			var venue = new Venue(new VenueId())
+			var venue = new Venue(id)
 			{
 				Name = name,
 				Surface = surface


### PR DESCRIPTION
The Player, Venue, and Court entities will me managed in other Bounded Contexts. In this Bounded Context, they are simply going to be reference objects. Hence their IDs will be assigned to them by the Bounded Contexts that manage them, and in this Bounded Contexts we will simply use that ID (rather than assigning them a new one).

Hence when we create them in this Bounded Context, don't generate their IDs here. They will be passed in.