### PR TITLE
Create player

### DIFF
--- a/src/Common/DomainDesign.Common/ICommandHandler.cs
+++ b/src/Common/DomainDesign.Common/ICommandHandler.cs
@@ -2,6 +2,11 @@
 
 namespace DomainDesign.Common
 {
+	public interface ICommandHandler<TCommand> where TCommand : ICommand
+	{
+		Result Handle(TCommand command);
+	}
+
 	public interface ICommandHandler<TCommand, TResult> where TCommand : ICommand
 	{
 		Result<TResult> Handle(TCommand command);

--- a/src/Tennis.sln
+++ b/src/Tennis.sln
@@ -17,7 +17,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TournamentManagement.Domain
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TournamentManagement.WebApi", "TournamentManagement\TournamentManagement.WebApi\TournamentManagement.WebApi.csproj", "{5E9DCE74-EE23-47B7-B14D-E9BDDE6EBA81}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TournamentManagement.Application", "TournamentManagement\TournamentManagement.Application\TournamentManagement.Application.csproj", "{3761695D-06BD-4A09-A9C9-3FD5A420FBBE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TournamentManagement.Application", "TournamentManagement\TournamentManagement.Application\TournamentManagement.Application.csproj", "{3761695D-06BD-4A09-A9C9-3FD5A420FBBE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TournamentManagement.Common", "TournamentManagement\TournamentManagement.Common\TournamentManagement.Common.csproj", "{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -101,6 +103,18 @@ Global
 		{3761695D-06BD-4A09-A9C9-3FD5A420FBBE}.Release|x64.Build.0 = Release|Any CPU
 		{3761695D-06BD-4A09-A9C9-3FD5A420FBBE}.Release|x86.ActiveCfg = Release|Any CPU
 		{3761695D-06BD-4A09-A9C9-3FD5A420FBBE}.Release|x86.Build.0 = Release|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Debug|x64.Build.0 = Debug|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Debug|x86.Build.0 = Debug|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Release|x64.ActiveCfg = Release|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Release|x64.Build.0 = Release|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Release|x86.ActiveCfg = Release|Any CPU
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,6 +126,7 @@ Global
 		{BDE642C0-E002-464B-94E4-36023720CB8C} = {32CCE864-ACCA-4912-9C18-EE3FFD706644}
 		{5E9DCE74-EE23-47B7-B14D-E9BDDE6EBA81} = {32CCE864-ACCA-4912-9C18-EE3FFD706644}
 		{3761695D-06BD-4A09-A9C9-3FD5A420FBBE} = {32CCE864-ACCA-4912-9C18-EE3FFD706644}
+		{4F1387AE-DDCB-431F-A8FC-C7B4766C6B77} = {32CCE864-ACCA-4912-9C18-EE3FFD706644}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8A0BBE81-6905-4BD2-86DB-44B6D43B4DEF}

--- a/src/TournamentManagement/TournamentManagement.Application/RegisterPlayerCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/RegisterPlayerCommand.cs
@@ -16,7 +16,7 @@ namespace TournamentManagement.Application
 		public Gender Gender { get; set; }
 	}
 
-	public sealed class RegisterPlayerCommandHandler : ICommandHandler<RegisterPlayerCommand, Guid>
+	public sealed class RegisterPlayerCommandHandler : ICommandHandler<RegisterPlayerCommand>
 	{
 		private IPlayerRepository _playerRepository;
 
@@ -25,16 +25,16 @@ namespace TournamentManagement.Application
 			_playerRepository = tournamentRepository;
 		}
 
-		public Result<Guid> Handle(RegisterPlayerCommand command)
+		public Result Handle(RegisterPlayerCommand command)
 		{
 			var playerId = new PlayerId(command.Id);
 			var player = Player.Register(playerId, command.Name, command.SinglesRank,
 				command.DoublesRank, command.Gender);
 
 			// add player to the repository
-			// save the repository (or nit of work
+			// save the repository (or unit of work)
 
-			return Result.Success(player.Id.Id);
+			return Result.Success();
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Application/RegisterPlayerCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/RegisterPlayerCommand.cs
@@ -1,0 +1,40 @@
+﻿using CSharpFunctionalExtensions;
+using DomainDesign.Common;
+using System;
+using TournamentManagement.Common;
+using TournamentManagement.Domain.PlayerAggregate;
+using TournamentManagement.Domain.PlayerAggregate.Repository;
+
+namespace TournamentManagement.Application
+{
+	public sealed class RegisterPlayerCommand : ICommand
+	{
+		public Guid Id { get; set; }
+		public string Name { get; set; }
+		public ushort SinglesRank { get; set; }
+		public ushort DoublesRank { get; set; }
+		public Gender Gender { get; set; }
+	}
+
+	public sealed class RegisterPlayerCommandHandler : ICommandHandler<RegisterPlayerCommand, Guid>
+	{
+		private IPlayerRepository _playerRepository;
+
+		public RegisterPlayerCommandHandler(IPlayerRepository tournamentRepository)
+		{
+			_playerRepository = tournamentRepository;
+		}
+
+		public Result<Guid> Handle(RegisterPlayerCommand command)
+		{
+			var playerId = new PlayerId(command.Id);
+			var player = Player.Register(playerId, command.Name, command.SinglesRank,
+				command.DoublesRank, command.Gender);
+
+			// add player to the repository
+			// save the repository (or nit of work
+
+			return Result.Success(player.Id.Id);
+		}
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Application/UpdatePlayerRankingsCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/UpdatePlayerRankingsCommand.cs
@@ -1,0 +1,34 @@
+﻿using CSharpFunctionalExtensions;
+using DomainDesign.Common;
+using System;
+using TournamentManagement.Domain.PlayerAggregate.Repository;
+
+namespace TournamentManagement.Application
+{
+	public class UpdatePlayerRankingsCommand : ICommand
+	{
+		public Guid Id { get; set; }
+		public ushort SinglesRank { get; set; }
+		public ushort DoublesRank { get; set; }
+	}
+
+	public sealed class UpdatePlayerRankingsCommandHandler : ICommandHandler<UpdatePlayerRankingsCommand>
+	{
+		private IPlayerRepository _playerRepository;
+
+		public UpdatePlayerRankingsCommandHandler(IPlayerRepository tournamentRepository)
+		{
+			_playerRepository = tournamentRepository;
+		}
+
+		public Result Handle(UpdatePlayerRankingsCommand command)
+		{
+			var player = _playerRepository.GetById(command.Id);
+			if (player == null) return Result.Failure("Player Not Found");
+
+			player.UpdateRankings(command.SinglesRank, command.DoublesRank);
+
+			return Result.Success();
+		}
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Common/Gender.cs
+++ b/src/TournamentManagement/TournamentManagement.Common/Gender.cs
@@ -1,0 +1,8 @@
+﻿namespace TournamentManagement.Common
+{
+	public enum Gender
+	{
+		Male,
+		Female
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Common/TournamentManagement.Common.csproj
+++ b/src/TournamentManagement/TournamentManagement.Common/TournamentManagement.Common.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/PlayerAggregate/PlayerTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/PlayerAggregate/PlayerTests.cs
@@ -12,7 +12,7 @@ namespace TournamentManagement.Domain.UnitTests.PlayerAggregate
 		public void CanUseFactoryMethodToCreatePlayerAndItIsCreatedCorrectly()
 		{
 			var playerId = new PlayerId();
-			var player = Player.Create(playerId, "Steve Serve", 10, 200, Gender.Male);
+			var player = Player.Register(playerId, "Steve Serve", 10, 200, Gender.Male);
 
 			player.Id.Should().Be(playerId);
 			player.Name.Should().Be("Steve Serve");
@@ -27,7 +27,7 @@ namespace TournamentManagement.Domain.UnitTests.PlayerAggregate
 		[InlineData("")]
 		public void CannotCreateAPlayerWithEmptyName(string name)
 		{
-			Action act = () => Player.Create(new PlayerId(), name, 100, 200, Gender.Female);
+			Action act = () => Player.Register(new PlayerId(), name, 100, 200, Gender.Female);
 
 			act.Should()
 				.Throw<ArgumentException>()
@@ -41,7 +41,7 @@ namespace TournamentManagement.Domain.UnitTests.PlayerAggregate
 		[InlineData(9999)]
 		public void CanCreateAPlayerWithRankValuesAtTheLimitsOfTheValidRange(ushort rank)
 		{
-			var player = Player.Create(new PlayerId(), "Steve Serve", rank, rank, Gender.Male);
+			var player = Player.Register(new PlayerId(), "Steve Serve", rank, rank, Gender.Male);
 
 			player.SinglesRank.Should().Be(rank);
 			player.DoublesRank.Should().Be(rank);
@@ -52,13 +52,44 @@ namespace TournamentManagement.Domain.UnitTests.PlayerAggregate
 		[InlineData(100, 0)]
 		[InlineData(10000, 100)]
 		[InlineData(100, 10000)]
-		public void CanCreatePlayerWithRankValuesOutsideTheValidRange(ushort singlesRank, ushort doublesRank)
+		public void CannotCreatePlayerWithRankValuesOutsideTheValidRange(ushort singlesRank, ushort doublesRank)
 		{
-			Action act = () => Player.Create(new PlayerId(), "Steve Serve", singlesRank, doublesRank,
+			Action act = () => Player.Register(new PlayerId(), "Steve Serve", singlesRank, doublesRank,
 				Gender.Female);
 
 			act.Should()
-				.Throw<ArgumentException>();
+				.Throw<ArgumentException>()
+				.WithMessage("*Rank * is outside allowed range, 1 - 9999");
+		}
+
+		[Theory]
+		[InlineData(1)]
+		[InlineData(9999)]
+		public void CanUpdatePlayersRankWithValuesAtTheLimitsOfTheValidRange(ushort rank)
+		{
+			var player = Player.Register(new PlayerId(), "Doris Dropshot", 100, 200, Gender.Female);
+
+			player.UpdateRankings(rank, rank);
+
+			player.SinglesRank.Should().Be(rank);
+			player.DoublesRank.Should().Be(rank);
+		}
+
+		[Theory]
+		[InlineData(0, 100)]
+		[InlineData(100, 0)]
+		[InlineData(10000, 100)]
+		[InlineData(100, 10000)]
+		public void CannotUpdatePlayerRankWithRankValuesOutsideTheValidRange(ushort singlesRank,
+			ushort doublesRank)
+		{
+			var player = Player.Register(new PlayerId(), "Doris Dropshot", 100, 200, Gender.Female);
+
+			Action act = () => player.UpdateRankings(singlesRank, doublesRank);
+
+			act.Should()
+				.Throw<ArgumentException>()
+				.WithMessage("*Rank * is outside allowed range, 1 - 9999");
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/PlayerAggregate/PlayerTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/PlayerAggregate/PlayerTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using System;
-using TournamentManagement.Domain.Common;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using Xunit;
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventEntryTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventEntryTests.cs
@@ -16,7 +16,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		{
 			var eventId = new EventId();
 			var playerId = new PlayerId();
-			var player = Player.Create(playerId, "Steve Server", 20, 100, gender);
+			var player = Player.Register(playerId, "Steve Server", 20, 100, gender);
 
 			var entry = EventEntry.CreateSinglesEventEntry(eventId, eventType, player);
 
@@ -35,8 +35,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			Gender genderOne, Gender genderTwo)
 		{
 			var eventId = new EventId();
-			var playerOne = Player.Create(new PlayerId(), "Steve Server", 20, 100, genderOne);
-			var playerTwo = Player.Create(new PlayerId(), "Gary Groundstroke", 30, 50, genderTwo);
+			var playerOne = Player.Register(new PlayerId(), "Steve Server", 20, 100, genderOne);
+			var playerTwo = Player.Register(new PlayerId(), "Gary Groundstroke", 30, 50, genderTwo);
 
 			var entry = EventEntry.CreateDoublesEventEntry(eventId, eventType, playerOne, playerTwo);
 
@@ -53,8 +53,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannotCreateSinglesEntryForADoublesEventType(EventType eventType)
 		{
 			var eventId = new EventId();
-			var playerOne = Player.Create(new PlayerId(), "Steve Server", 20, 100, Gender.Male);
-			var playerTwo = Player.Create(new PlayerId(), "Gary Groundstroke", 30, 50, Gender.Male);
+			var playerOne = Player.Register(new PlayerId(), "Steve Server", 20, 100, Gender.Male);
+			var playerTwo = Player.Register(new PlayerId(), "Gary Groundstroke", 30, 50, Gender.Male);
 
 			Action act = () => EventEntry.CreateDoublesEventEntry(eventId, eventType, playerOne, playerTwo);
 
@@ -70,7 +70,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannotCreateDoublesEntryToSinglesEvent(EventType eventType)
 		{
 			var eventId = new EventId();
-			var player = Player.Create(new PlayerId(), "Steve Server", 20, 100, Gender.Male);
+			var player = Player.Register(new PlayerId(), "Steve Server", 20, 100, Gender.Male);
 
 			Action act = () => EventEntry.CreateSinglesEventEntry(eventId, eventType, player);
 
@@ -85,7 +85,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void IfGenderDoesNotMatchSinglesEventThenExceptionIsThrown(EventType eventType, Gender gender)
 		{
 			var eventId = new EventId();
-			var player = Player.Create(new PlayerId(), "Steve Server", 20, 100, gender);
+			var player = Player.Register(new PlayerId(), "Steve Server", 20, 100, gender);
 
 			Action act = () => EventEntry.CreateSinglesEventEntry(eventId, eventType, player);
 
@@ -102,8 +102,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			Gender genderOne, Gender genderTwo)
 		{
 			var eventId = new EventId();
-			var playerOne = Player.Create(new PlayerId(), "Steve Server", 20, 100, genderOne);
-			var playerTwo = Player.Create(new PlayerId(), "Gary Groundstroke", 30, 50, genderTwo);
+			var playerOne = Player.Register(new PlayerId(), "Steve Server", 20, 100, genderOne);
+			var playerTwo = Player.Register(new PlayerId(), "Gary Groundstroke", 30, 50, genderTwo);
 
 			Action act = () => EventEntry.CreateDoublesEventEntry(eventId, eventType, playerOne, playerTwo);
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventEntryTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventEntryTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using System;
-using TournamentManagement.Domain.Common;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate;
 using Xunit;

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using System;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate;

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
@@ -90,7 +90,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		{
 			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
-			var player = Player.Create(new PlayerId(), "Steve", 100, 50, Gender.Male);
+			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var entry = EventEntry.CreateSinglesEventEntry(tennisEvent.Id, tennisEvent.EventType, player);
 
 			tennisEvent.AddEventEntry(entry);
@@ -105,10 +105,10 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
-			var player = Player.Create(new PlayerId(), "Steve", 100, 50, Gender.Male);
+			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var entry = EventEntry.CreateSinglesEventEntry(tennisEvent.Id, tennisEvent.EventType, player);
 			tennisEvent.AddEventEntry(entry);
-			player = Player.Create(new PlayerId(), "Dave", 101, 52, Gender.Male);
+			player = Player.Register(new PlayerId(), "Dave", 101, 52, Gender.Male);
 			entry = EventEntry.CreateSinglesEventEntry(tennisEvent.Id, tennisEvent.EventType, player);
 			tennisEvent.AddEventEntry(entry);
 			tennisEvent.Entries.Count.Should().Be(2);
@@ -124,10 +124,10 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
-			var player = Player.Create(new PlayerId(), "Steve", 100, 50, Gender.Male);
+			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var entry = EventEntry.CreateSinglesEventEntry(tennisEvent.Id, tennisEvent.EventType, player);
 			tennisEvent.AddEventEntry(entry);
-			player = Player.Create(new PlayerId(), "Dave", 101, 52, Gender.Male);
+			player = Player.Register(new PlayerId(), "Dave", 101, 52, Gender.Male);
 			entry = EventEntry.CreateSinglesEventEntry(tennisEvent.Id, tennisEvent.EventType, player);
 			tennisEvent.AddEventEntry(entry);
 			tennisEvent.Entries.Count.Should().Be(2);
@@ -142,7 +142,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		{
 			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
-			var player = Player.Create(new PlayerId(), "Venus", 100, 50, Gender.Female);
+			var player = Player.Register(new PlayerId(), "Venus", 100, 50, Gender.Female);
 			var entry = EventEntry.CreateSinglesEventEntry(tennisEvent.Id, EventType.WomensSingles, player);
 
 			Action act = () => tennisEvent.AddEventEntry(entry);
@@ -157,7 +157,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		{
 			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
-			var player = Player.Create(new PlayerId(), "Steve", 100, 50, Gender.Male);
+			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var entry = EventEntry.CreateSinglesEventEntry(new EventId(), EventType.MensSingles, player);
 
 			Action act = () => tennisEvent.AddEventEntry(entry);

--- a/src/TournamentManagement/TournamentManagement.Domain/Common/Gender.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Common/Gender.cs
@@ -1,8 +1,0 @@
-﻿namespace TournamentManagement.Domain.Common
-{
-	public enum Gender
-	{
-		Male,
-		Female
-	}
-}

--- a/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
@@ -1,14 +1,13 @@
 ﻿using Ardalis.GuardClauses;
 using DomainDesign.Common;
-using System;
 using TournamentManagement.Domain.Common;
 
 namespace TournamentManagement.Domain.PlayerAggregate
 {
 	public class Player : Entity<PlayerId>, IAggregateRoot
 	{
-		private const uint MinRank = 1;
-		private const uint MaxRank = 9999;
+		private const ushort MinRank = 1;
+		private const ushort MaxRank = 9999;
 
 		public string Name { get; private set; }
 		public ushort SinglesRank { get; private set; }
@@ -19,7 +18,7 @@ namespace TournamentManagement.Domain.PlayerAggregate
 		{
 		}
 
-		public static Player Create(PlayerId id, string name, ushort singlesRank,
+		public static Player Register(PlayerId id, string name, ushort singlesRank,
 			ushort doublesRank, Gender gender)
 		{
 			Guard.Against.NullOrWhiteSpace(name, nameof(name));
@@ -37,12 +36,16 @@ namespace TournamentManagement.Domain.PlayerAggregate
 			return player;
 		}
 
-		private static void GuardAgainstRankOutOfRange(ushort rank, string rankName)
+		public void UpdateRankings(ushort singlesRank, ushort doublesRank)
 		{
-			if (rank < MinRank || rank > MaxRank)
-			{
-				throw new ArgumentException($"{rankName} {rank} is outside allowed range, {MinRank} - {MaxRank}");
-			}
+			SinglesRank = GuardAgainstRankOutOfRange(singlesRank, nameof(singlesRank));
+			DoublesRank = GuardAgainstRankOutOfRange(doublesRank, nameof(doublesRank));
+		}
+
+		private static ushort GuardAgainstRankOutOfRange(ushort rank, string rankName)
+		{
+			return Guard.Against.OutOfRange(rank, rankName, MinRank, MaxRank,
+				$"{rankName} {rank} is outside allowed range, {MinRank} - {MaxRank}");
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
@@ -1,6 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using DomainDesign.Common;
-using TournamentManagement.Domain.Common;
+using TournamentManagement.Common;
 
 namespace TournamentManagement.Domain.PlayerAggregate
 {

--- a/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Repository/IPlayerRepository.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Repository/IPlayerRepository.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TournamentManagement.Domain.PlayerAggregate.Repository
 {
 	public interface IPlayerRepository
 	{
+		Player GetById(Guid id);
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Repository/IPlayerRepository.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Repository/IPlayerRepository.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TournamentManagement.Domain.PlayerAggregate.Repository
+{
+	public interface IPlayerRepository
+	{
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventEntry.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventEntry.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using TournamentManagement.Domain.Common;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 
 namespace TournamentManagement.Domain.TournamentAggregate

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentManagement.Domain.csproj
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentManagement.Domain.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Common\DomainDesign.Common\DomainDesign.Common.csproj" />
+    <ProjectReference Include="..\TournamentManagement.Common\TournamentManagement.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

Firstly, the Player entity has been updated so the the Create is now called Register. It has also been extended so that there is an UpdateRankings method to update the rankings of an existing player.

A new project was created TournamentManagement.Common to hold types that are not specific to a single layer in the bounded context. The first type moved to this project was Gender.

Added to new Commands (and their handlers): RegisterPlayer and UpdatePlayerRankings. These are not the finished article, but a work in progress. Also the repository Interfaces are just shells at the moment.