### PR TITLE
Fix issue with reading Venue with its Courts

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Console/Program.cs
+++ b/src/TournamentManagement/TournamentManagement.Console/Program.cs
@@ -100,10 +100,9 @@ namespace TournamentManagement.Console
 		{
 			using var context = new TournamentManagementDbContext(optionsBuilder.Options);
 
-			// This goes pop at the moment - need to configure to use backing field and not read-only collection
-			//var venue = context.Venues
-			//	.Include(v => v.Courts)
-			//	.First(v => v.Id == new VenueId(venueGuid));
+			var venue = context.Venues
+				.Include(v => v.Courts)
+				.First(v => v.Id == new VenueId(venueGuid));
 		}
 
 		private static Guid CreateTournament(DbContextOptionsBuilder<TournamentManagementDbContext> optionsBuilder,

--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
@@ -130,10 +130,8 @@ namespace TournamentManagement.Data
 				.HasMaxLength(50)
 				.IsRequired();
 			builder.Property(p => p.Surface);
-
-			//To Do: Solve this problem
-			//var navigation = builder.Metadata.FindNavigation(nameof(Venue.Courts));
-			//navigation.SetPropertyAccessMode(PropertyAccessMode.Field);
+			builder.HasMany(b => b.Courts).WithOne()
+				.Metadata.PrincipalToDependent.SetPropertyAccessMode(PropertyAccessMode.Field);
 		}
 	}
 
@@ -148,11 +146,6 @@ namespace TournamentManagement.Data
 				.HasMaxLength(50)
 				.IsRequired();
 			builder.Property(p => p.Capacity);
-			builder.HasOne<Venue>()
-				.WithMany()
-				.HasForeignKey(p => p.VenueId);
-			builder.Property(p => p.VenueId)
-				.HasConversion(p => p.Id, p => new VenueId(p));
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/VenueAggregate/CourtTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/VenueAggregate/CourtTests.cs
@@ -11,13 +11,11 @@ namespace TournamentManagement.Domain.UnitTests.VenueAggregate
 		public void CanUseFactoryMethodToCreateCourtAndItIsCreatedCorrectly()
 		{
 			var courtId = new CourtId();
-			var venueId = new VenueId();
-			var court = Court.Create(courtId, "Centre Court", 14979, venueId);
+			var court = Court.Create(courtId, "Centre Court", 14979);
 
 			court.Id.Should().Be(courtId);
 			court.Name.Should().Be("Centre Court");
 			court.Capacity.Should().Be(14979);
-			court.VenueId.Should().Be(venueId);
 		}
 
 		[Theory]
@@ -26,7 +24,7 @@ namespace TournamentManagement.Domain.UnitTests.VenueAggregate
 		[InlineData("")]
 		public void CannotCreateACourtWithEmptyName(string name)
 		{
-			Action act = () => Court.Create(new CourtId(), name, 100, new VenueId());
+			Action act = () => Court.Create(new CourtId(), name, 100);
 
 			act.Should()
 				.Throw<ArgumentException>()
@@ -40,7 +38,7 @@ namespace TournamentManagement.Domain.UnitTests.VenueAggregate
 		[InlineData(25000)]
 		public void CanCreateACourtWithCapacityValuesAtTheLimitsOfTheValidRange(int capacity)
 		{
-			var court = Court.Create(new CourtId(), "Centre Court", capacity, new VenueId());
+			var court = Court.Create(new CourtId(), "Centre Court", capacity);
 
 			court.Name.Should().Be("Centre Court");
 			court.Capacity.Should().Be(capacity);
@@ -51,7 +49,7 @@ namespace TournamentManagement.Domain.UnitTests.VenueAggregate
 		[InlineData(25001)]
 		public void CannotCreateCourtWithCapacityValuesOutsideTheValidRange(int capacity)
 		{
-			Action act = () => Court.Create(new CourtId(), "Centre Court", capacity, new VenueId());
+			Action act = () => Court.Create(new CourtId(), "Centre Court", capacity);
 
 			act.Should()
 				.Throw<ArgumentException>();
@@ -60,7 +58,7 @@ namespace TournamentManagement.Domain.UnitTests.VenueAggregate
 		[Fact]
 		public void CanRenameACourt()
 		{
-			var court = Court.Create(new CourtId(), "Centre Court", 14979, new VenueId());
+			var court = Court.Create(new CourtId(), "Centre Court", 14979);
 
 			court.RenameCourt("Murray Court");
 
@@ -70,7 +68,7 @@ namespace TournamentManagement.Domain.UnitTests.VenueAggregate
 		[Fact]
 		public void CanUpdateTheCapacityOfACourt()
 		{
-			var court = Court.Create(new CourtId(), "Court 4", 100, new VenueId());
+			var court = Court.Create(new CourtId(), "Court 4", 100);
 
 			court.UpdateCapacity(200);
 
@@ -82,7 +80,7 @@ namespace TournamentManagement.Domain.UnitTests.VenueAggregate
 		[InlineData("")]
 		public void CannotRenameACourtWithEmptyName(string newName)
 		{
-			var court = Court.Create(new CourtId(), "Court 4", 100, new VenueId());
+			var court = Court.Create(new CourtId(), "Court 4", 100);
 
 			Action act = () => court.RenameCourt(newName);
 
@@ -98,7 +96,7 @@ namespace TournamentManagement.Domain.UnitTests.VenueAggregate
 		[InlineData(25001)]
 		public void CannotUpdateCapacityWithValueOutsideTheValidRange(int capacity)
 		{
-			var court = Court.Create(new CourtId(), "Court 4", 100, new VenueId());
+			var court = Court.Create(new CourtId(), "Court 4", 100);
 
 			Action act = () => court.UpdateCapacity(capacity);
 

--- a/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Court.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Court.cs
@@ -13,13 +13,12 @@ namespace TournamentManagement.Domain.VenueAggregate
 
 		public string Name { get; private set; }
 		public int Capacity { get; private set; }
-		public VenueId VenueId { get; private set; }
 
 		private Court(CourtId id) : base(id)
 		{
 		}
 
-		internal static Court Create(CourtId id, string name, int capacity, VenueId venueId)
+		internal static Court Create(CourtId id, string name, int capacity)
 		{
 			Guard.Against.NullOrWhiteSpace(name, nameof(name));
 			Guard.Against.IntegerOutOfRange(capacity, MinCapacity, MaxCapacity, nameof(capacity));
@@ -27,8 +26,7 @@ namespace TournamentManagement.Domain.VenueAggregate
 			var court = new Court(id)
 			{
 				Name = name,
-				Capacity = capacity,
-				VenueId = venueId
+				Capacity = capacity
 			};
 
 			return court;

--- a/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Venue.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Venue.cs
@@ -2,7 +2,6 @@
 using DomainDesign.Common;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace TournamentManagement.Domain.VenueAggregate
@@ -11,14 +10,16 @@ namespace TournamentManagement.Domain.VenueAggregate
 	{
 		public string Name { get; private set; }
 		public Surface Surface { get; private set; }
-		public ReadOnlyCollection<Court> Courts { get; }
 
-		private readonly IList<Court> _courts;
+		private readonly List<Court> _courts = new();
+		public virtual IReadOnlyList<Court> Courts => _courts.ToList();
+
+		protected Venue()
+		{
+		}
 
 		private Venue(VenueId id) : base(id)
 		{
-			_courts = new List<Court>();
-			Courts = new ReadOnlyCollection<Court>(_courts);
 		}
 
 		public static Venue Create(VenueId id, string name, Surface surface)
@@ -37,7 +38,7 @@ namespace TournamentManagement.Domain.VenueAggregate
 		public void AddCourt(CourtId id, string name, int capacity)
 		{
 			GuardAgainstDuplicateCourtName(name);
-			var court = Court.Create(id, name, capacity, Id);
+			var court = Court.Create(id, name, capacity);
 			_courts.Add(court);
 		}
 


### PR DESCRIPTION
Two bits to this one:

First, EF core does not mandate that you have to have the ID of the "one" on the "many" in a one-to-many relationship. EF can work things out by convention. As Court has no need for the Venue Id in the Domain Layer, it has been removed. Removing this changed the way the EF model is defined

Was struggling to get EF to work with the way the Read Only collection (i.e use the backing field). Changed the way this was working.