### PR TITLE
Encapsulate DbContext

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagement.Data.csproj
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagement.Data.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using the Options Builder outside of the DB Context class is a big hole in encapsulation. We want to minimise the surface area of the API for the DB Context class to help with encapsulation and simplification. 