### PR TITLE
Simplify relationships between Tournament and Event

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Console/Program.cs
+++ b/src/TournamentManagement/TournamentManagement.Console/Program.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using TournamentManagement.Common;
 using TournamentManagement.Data;
 using TournamentManagement.Domain;
+using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate;
 using TournamentManagement.Domain.VenueAggregate;
@@ -30,6 +31,7 @@ namespace TournamentManagement.Console
 
 			var tournamentGuid = CreateTournament(connectionString, useConsoleLogger, venueGuid);
 			ReadTournament(connectionString, useConsoleLogger, tournamentGuid);
+			ReadTournamentAndEvents(connectionString, useConsoleLogger, tournamentGuid);
 		}
 
 		private static void EnsureDatabaseIsCreated(string connectionString, bool useConsoleLogger)
@@ -104,6 +106,9 @@ namespace TournamentManagement.Console
 			var tournament = Tournament.Create("Wimbledon 2022", TournamentLevel.GrandSlam,
 				new DateTime(2022, 07, 22), new DateTime(2022, 07, 29), new VenueId(venueGuid));
 
+			tournament.AddEvent(Event.Create(EventType.MensSingles, 128, 32, new MatchFormat(5, SetType.TieBreakAtTwelveAll)));
+			tournament.AddEvent(Event.Create(EventType.WomensSingles, 128, 32, new MatchFormat(3, SetType.TieBreakAtTwelveAll)));
+
 			context.Tournaments.Add(tournament);
 			context.SaveChanges();
 
@@ -114,6 +119,14 @@ namespace TournamentManagement.Console
 		{
 			using var context = new TournamentManagementDbContext(connectionString, useConsoleLogger);
 			var tournament = context.Tournaments.Find(new TournamentId(tournamentGuid));
+		}
+
+		private static void ReadTournamentAndEvents(string connectionString, bool useConsoleLogger, Guid tournamentGuid)
+		{
+			using var context = new TournamentManagementDbContext(connectionString, useConsoleLogger);
+			var tournament = context.Tournaments
+				.Include(t => t.Events)
+				.First(t => t.Id == new TournamentId(tournamentGuid));
 		}
 
 		private static string GetConnectionString()

--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
@@ -80,7 +80,7 @@ namespace TournamentManagement.Data
 				.HasForeignKey(p => p.VenueId);
 			builder.Property(p => p.VenueId)
 				.HasConversion(p => p.Id, p => new VenueId(p));
-			builder.Ignore(p => p.Events);
+			//builder.HasMany(b => b.Events).WithOne()
 		}
 	}
 
@@ -106,12 +106,6 @@ namespace TournamentManagement.Data
 				p.Property(pp => pp.NumberOfSets).HasColumnName("NumberOfSets");
 				p.Property(pp => pp.FinalSetType).HasColumnName("FinalSetType");
 			});
-
-			builder.HasOne<Tournament>()
-				.WithMany()
-				.HasForeignKey(p => p.TournamentId);
-			builder.Property(p => p.TournamentId)
-				.HasConversion(p => p.Id, p => new TournamentId(p));
 		}
 	}
 

--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
@@ -80,7 +80,9 @@ namespace TournamentManagement.Data
 				.HasForeignKey(p => p.VenueId);
 			builder.Property(p => p.VenueId)
 				.HasConversion(p => p.Id, p => new VenueId(p));
-			//builder.HasMany(b => b.Events).WithOne()
+			  
+			builder.HasMany(b => b.Events).WithOne()
+				.Metadata.PrincipalToDependent.SetPropertyAccessMode(PropertyAccessMode.Field);
 		}
 	}
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
@@ -13,12 +13,10 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CanCreateAnEventUsingTheFactory()
 		{
-			var tournamentId = new TournamentId();
-			var tennisEvent = Event.Create(tournamentId, EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
 			tennisEvent.Id.Id.Should().NotBe(Guid.Empty);
-			tennisEvent.TournamentId.Should().Be(tournamentId);
 			tennisEvent.IsCompleted.Should().BeFalse();
 			tennisEvent.EventType.Should().Be(EventType.MensSingles);
 			tennisEvent.MatchFormat.Should().Be(MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
@@ -34,8 +32,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[InlineData(EventType.WomensSingles, true)]
 		public void TheIsSinglesEventPropertyIsSetCorrectlyBasedOnEventType(EventType eventType, bool isSingles)
 		{
-			var tennisEvent = Event.Create(new TournamentId(), eventType, 128, 32,
-				new MatchFormat(1, SetType.TieBreak));
+			var tennisEvent = Event.Create(eventType, 128, 32, new MatchFormat(1, SetType.TieBreak));
 
 			tennisEvent.SinglesEvent.Should().Be(isSingles);
 		}
@@ -43,7 +40,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CanUpdateAnEvent()
 		{
-			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
 			var id = tennisEvent.Id;
@@ -61,7 +58,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CanMarkAnEventAsCompleted()
 		{
-			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
 			tennisEvent.IsCompleted.Should().BeFalse();
@@ -74,7 +71,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CannotUpdateAnEventThatIsCompleted()
 		{
-			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 			tennisEvent.MarkEventCompleted();
 
@@ -89,7 +86,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CanAddEntriesToAnEvent()
 		{
-			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var entry = EventEntry.CreateSinglesEventEntry(tennisEvent.Id, tennisEvent.EventType, player);
@@ -103,7 +100,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CanRemoveAnEnryFromAnEvent()
 		{
-			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
@@ -122,7 +119,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CanClearAllEntriesFromAnEvent()
 		{
-			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
@@ -141,7 +138,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CannotAddAnEntryToEventIfEventTypeDoesNotMatch()
 		{
-			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 			var player = Player.Register(new PlayerId(), "Venus", 100, 50, Gender.Female);
 			var entry = EventEntry.CreateSinglesEventEntry(tennisEvent.Id, EventType.WomensSingles, player);
@@ -156,7 +153,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[Fact]
 		public void CannotAddAnEntryToEventIfEventIdDoesNotMatch()
 		{
-			var tennisEvent = Event.Create(new TournamentId(), EventType.MensSingles, 128, 32,
+			var tennisEvent = Event.Create(EventType.MensSingles, 128, 32,
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var entry = EventEntry.CreateSinglesEventEntry(new EventId(), EventType.MensSingles, player);

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
@@ -60,7 +60,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanAddAnEventToATournament()
 		{
 			var tournament = CreateTestTournament();
-			var tennisEvent = CreateTestEvent(tournament.Id);
+			var tennisEvent = CreateTestEvent();
 
 			tournament.AddEvent(tennisEvent);
 
@@ -72,33 +72,21 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanAddAllTypesOfEventToATournament()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.WomensSingles));
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensDoubles));
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.WomensDoubles));
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MixedDoubles));
+			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.MensDoubles));
+			tournament.AddEvent(CreateTestEvent(EventType.WomensDoubles));
+			tournament.AddEvent(CreateTestEvent(EventType.MixedDoubles));
 
 			tournament.Events.Count.Should().Be(5);
-		}
-
-		[Fact]
-		public void CannotAddAnEventIfTheTournamentIdDoesNotMatch()
-		{
-			var tournament = CreateTestTournament();
-
-			Action act = () => tournament.AddEvent(CreateTestEvent(new TournamentId(), EventType.MensSingles));
-
-			act.Should()
-				.Throw<Exception>()
-				.WithMessage("Cannot add Event with the wrong Tournament Id");
 		}
 
 		[Fact]
 		public void CanRemoveAnEventFromATournament()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.WomensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
 
 			tournament.Events.Count.Should().Be(2);
 
@@ -112,9 +100,9 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannnotAddASecondEventOfTheSameTypeToATournament()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
 
-			Action act = () => tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensSingles));
+			Action act = () => tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
 
 			act.Should()
 				.Throw<Exception>()
@@ -125,7 +113,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannotRemoveAnEventTypeFromATournamentIfItDoesNotExist()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
 
 			tournament.Events.Count.Should().Be(1);
 
@@ -141,8 +129,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		{
 			var tournament = CreateTestTournament();
 
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.WomensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
 
 			tournament.Events.Count.Should().Be(2);
 
@@ -158,11 +146,11 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			var events = new List<Event>()
 			{
-				CreateTestEvent(tournament.Id, EventType.MensSingles),
-				CreateTestEvent(tournament.Id, EventType.WomensSingles),
-				CreateTestEvent(tournament.Id, EventType.MensDoubles),
-				CreateTestEvent(tournament.Id, EventType.WomensDoubles),
-				CreateTestEvent(tournament.Id, EventType.MixedDoubles)
+				CreateTestEvent(EventType.MensSingles),
+				CreateTestEvent(EventType.WomensSingles),
+				CreateTestEvent(EventType.MensDoubles),
+				CreateTestEvent(EventType.WomensDoubles),
+				CreateTestEvent(EventType.MixedDoubles)
 			};
 
 			
@@ -179,8 +167,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			var events = new List<Event>()
 			{
-				CreateTestEvent(tournament.Id, EventType.MensSingles),
-				CreateTestEvent(tournament.Id, EventType.MensSingles)
+				CreateTestEvent(EventType.MensSingles),
+				CreateTestEvent(EventType.MensSingles)
 			};
 
 			Action act = () => tournament.SetEvents(events);
@@ -196,8 +184,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanTransitionThroughTheStatesOfATournament()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.WomensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
 
 			tournament.OpenForEntries();
 			tournament.State.Should().Be(TournamentState.AcceptingEntries);
@@ -233,7 +221,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannotAddEventIfTournamentIsNotInBeingDefinedState()
 		{
 			var tournament = CreateTestTournamentAndOpenForEntries();
-			var tennisEvent = CreateTestEvent(tournament.Id, EventType.WomensSingles);
+			var tennisEvent = CreateTestEvent(EventType.WomensSingles);
 
 			void act() => tournament.AddEvent(tennisEvent);
 
@@ -338,16 +326,15 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 				new DateTime(2019, 7, 1), new DateTime(2019, 7, 14), new VenueId());
 		}
 
-		private static Event CreateTestEvent(TournamentId tournamentId, EventType eventtype = EventType.MensSingles)
+		private static Event CreateTestEvent(EventType eventtype = EventType.MensSingles)
 		{
-			return Event.Create(tournamentId, eventtype, 128, 32,
-				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
+			return Event.Create(eventtype, 128, 32, MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 		}
 
 		private static Tournament CreateTestTournamentAndOpenForEntries()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(tournament.Id, EventType.MensSingles));
+			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
 			tournament.OpenForEntries();
 			return tournament;
 		}

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
@@ -65,7 +65,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			tournament.AddEvent(tennisEvent);
 
 			tournament.Events.Count.Should().Be(1);
-			tournament.Events[EventType.MensSingles].EventSize.EntrantsLimit.Should().Be(128);
+			tournament.Events[0].EventSize.EntrantsLimit.Should().Be(128);
 		}
 
 		[Fact]
@@ -93,7 +93,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			tournament.RemoveEvent(EventType.MensSingles);
 
 			tournament.Events.Count.Should().Be(1);
-			tournament.Events[EventType.WomensSingles].EventSize.EntrantsLimit.Should().Be(128);
+			tournament.Events[0].EventType.Should().Be(EventType.WomensSingles);
 		}
 
 		[Fact]

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
@@ -10,7 +10,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 	public class Event : Entity<EventId>
 	{
 		public EventType EventType { get; private set; }
-		public bool SinglesEvent { get; private set; }
+		public bool SinglesEvent => IsSinglesEvent(EventType);
 		public MatchFormat MatchFormat { get; private set; }
 		public EventSize EventSize { get; private set; }
 		public bool IsCompleted { get; private set; }
@@ -72,7 +72,6 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		{
 			EventType = eventType;
 			MatchFormat = matchFormat;
-			SinglesEvent = IsSinglesEvent(eventType);
 			EventSize = new EventSize(entrantsLimit, numberOfSeeds);
 		}
 

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
@@ -9,7 +9,6 @@ namespace TournamentManagement.Domain.TournamentAggregate
 {
 	public class Event : Entity<EventId>
 	{
-		public TournamentId TournamentId { get; private set; }
 		public EventType EventType { get; private set; }
 		public bool SinglesEvent { get; private set; }
 		public MatchFormat MatchFormat { get; private set; }
@@ -26,13 +25,10 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			Entries = new ReadOnlyCollection<EventEntry>(_entries);
 		}
 
-		public static Event Create(TournamentId tournamentId, EventType eventType, int entrantsLimit,
+		public static Event Create(EventType eventType, int entrantsLimit,
 			int numberOfSeeds, MatchFormat matchFormat)
 		{
-			var tennisEvent = new Event(new EventId())
-			{
-				TournamentId = new TournamentId(tournamentId.Id)
-			};
+			var tennisEvent = new Event(new EventId());
 			tennisEvent.SetAttributeDetails(eventType, entrantsLimit, numberOfSeeds, matchFormat);
 			return tennisEvent;
 		}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Guards/TournamentGuards.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Guards/TournamentGuards.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using TournamentManagement.Domain.TournamentAggregate;
 
 namespace Ardalis.GuardClauses
@@ -30,18 +31,20 @@ namespace Ardalis.GuardClauses
 				"Tournament must have at least one event to open it for entries");
 		}
 
-		public static void DuplicateEventType<TKey, TValue>(this IGuardClause guardClause,
-			IDictionary<EventType, Event> events, EventType eventType)
+		public static void DuplicateEventType(this IGuardClause guardClause, IEnumerable<Event> events, EventType eventType)
 		{
-			Guard.Against.DictionaryAlreadyContainsKey(events, eventType, 
-				$"Tournament already has an event of type {eventType}");
+			if (events.Any(e => e.EventType == eventType))
+			{
+				throw new Exception($"Tournament already has an event of type {eventType}");
+			}
 		}
 
-		public static void MissingEventType<TKey, TValue>(this IGuardClause guardClause,
-			IDictionary<EventType, Event> events, EventType eventType)
+		public static void MissingEventType(this IGuardClause guardClause, IEnumerable<Event> events, EventType eventType)
 		{
-			Guard.Against.DictionaryDoesNotContainKey(events, eventType,
-				$"Tournament does not have an event of type {eventType}");
+			if (!events.Any(e => e.EventType == eventType))
+			{
+				throw new Exception($"Tournament does not have an event of type {eventType}");
+			}
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -59,10 +59,8 @@ namespace TournamentManagement.Domain.TournamentAggregate
 
 		public void AddEvent(Event tennisEvent)
 		{
-			const string WrongTournamentIdMessage = "Cannot add Event with the wrong Tournament Id";
 			Guard.Against.TournamentActionInWrongState(TournamentState.BeingDefined, State, nameof(AddEvent));
 			Guard.Against.DuplicateEventType<EventType, Event>(_events, tennisEvent.EventType); 
-			Guard.Against.KeyValuesDoNotMatch(tennisEvent.TournamentId, Id, WrongTournamentIdMessage);
 
 			_events.Add(tennisEvent.EventType, tennisEvent);
 		}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -2,7 +2,6 @@
 using DomainDesign.Common;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using TournamentManagement.Domain.VenueAggregate;
 
@@ -20,14 +19,15 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		public DateTime StartDate => Dates.StartDate;
 		public DateTime EndDate => Dates.EndDate;
 
-		public IReadOnlyDictionary<EventType, Event> Events { get; private set; }
+		private readonly List<Event> _events = new();
+		public virtual IReadOnlyList<Event> Events => _events.ToList();
 
-		private readonly IDictionary<EventType, Event> _events;
+		protected Tournament()
+		{
+		}
 
 		private Tournament(TournamentId id) : base(id)
 		{
-			_events = new Dictionary<EventType, Event>();
-			Events = new ReadOnlyDictionary<EventType, Event>(_events);
 		}
 
 		public static Tournament Create(string title, TournamentLevel level,
@@ -60,17 +60,18 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		public void AddEvent(Event tennisEvent)
 		{
 			Guard.Against.TournamentActionInWrongState(TournamentState.BeingDefined, State, nameof(AddEvent));
-			Guard.Against.DuplicateEventType<EventType, Event>(_events, tennisEvent.EventType); 
+			Guard.Against.DuplicateEventType(_events, tennisEvent.EventType); 
 
-			_events.Add(tennisEvent.EventType, tennisEvent);
+			_events.Add(tennisEvent);
 		}
 
 		public void RemoveEvent(EventType eventType)
 		{
 			Guard.Against.TournamentActionInWrongState(TournamentState.BeingDefined, State, nameof(RemoveEvent));
-			Guard.Against.MissingEventType<EventType, Event>(_events, eventType);
+			Guard.Against.MissingEventType(_events, eventType);
 
-			_events.Remove(eventType);
+			var tennisEvent = _events.First(e => e.EventType == eventType);
+			_events.Remove(tennisEvent);
 		}
 
 		public void ClearEvents()
@@ -90,8 +91,8 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			{
 				foreach (var tennisEvent in events)
 				{
-					Guard.Against.DuplicateEventType<EventType, Event>(_events, tennisEvent.EventType);
-					_events.Add(tennisEvent.EventType, tennisEvent);
+					Guard.Against.DuplicateEventType(_events, tennisEvent.EventType);
+					_events.Add(tennisEvent);
 				}
 			}
 			catch (Exception)
@@ -141,11 +142,11 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		public void EventCompleted(EventType eventType)
 		{
 			Guard.Against.TournamentActionInWrongState(TournamentState.InProgress, State, nameof(EventCompleted));
-			Guard.Against.MissingEventType<EventType, Event>(_events, eventType);
+			Guard.Against.MissingEventType(_events, eventType);
 
-			_events[eventType].MarkEventCompleted();
+			_events.First(e => e.EventType == eventType).MarkEventCompleted();
 
-			if (_events.Values.All(e => e.IsCompleted))
+			if (_events.All(e => e.IsCompleted))
 			{
 				TransitionToState(TournamentState.Complete);
 


### PR DESCRIPTION
In the Domain Model, there is no need for Event to have the ID of its parent Tournament (that is only needed in the database)

To simplify things (i.e. mapping to the database), the collection of Events the Tournament has, has been changed from a dictionary to a list.
