### PR TITLE
Replace VenueId on Tournament with a Venue Nav property

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Application/AddTournamentCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/AddTournamentCommand.cs
@@ -27,8 +27,11 @@ namespace TournamentManagement.Application
 
 		public Result<Guid> Handle(AddTournamentCommand command)
 		{
+			// retrieve the Venue based on its ID
+			var venue = Venue.Create(new VenueId(command.VenueId), "Roland Garros", Domain.Surface.Clay);
+
 			var tournament = Tournament.Create(command.Title, TournamentLevel.GrandSlam,
-					command.StartDate, command.EndDate, new VenueId(command.VenueId));
+					command.StartDate, command.EndDate, venue);
 
 			// add tournament to the repository
 			// save the repository

--- a/src/TournamentManagement/TournamentManagement.Console/Program.cs
+++ b/src/TournamentManagement/TournamentManagement.Console/Program.cs
@@ -32,6 +32,7 @@ namespace TournamentManagement.Console
 			var tournamentGuid = CreateTournament(connectionString, useConsoleLogger, venueGuid);
 			ReadTournament(connectionString, useConsoleLogger, tournamentGuid);
 			ReadTournamentAndEvents(connectionString, useConsoleLogger, tournamentGuid);
+			ReadTournamentAndVenue(connectionString, useConsoleLogger, tournamentGuid);
 		}
 
 		private static void EnsureDatabaseIsCreated(string connectionString, bool useConsoleLogger)
@@ -103,8 +104,10 @@ namespace TournamentManagement.Console
 		{
 			using var context = new TournamentManagementDbContext(connectionString, useConsoleLogger);
 
+			var venue = context.Venues.Find(new VenueId(venueGuid));
+
 			var tournament = Tournament.Create("Wimbledon 2022", TournamentLevel.GrandSlam,
-				new DateTime(2022, 07, 22), new DateTime(2022, 07, 29), new VenueId(venueGuid));
+				new DateTime(2022, 07, 22), new DateTime(2022, 07, 29), venue);
 
 			tournament.AddEvent(Event.Create(EventType.MensSingles, 128, 32, new MatchFormat(5, SetType.TieBreakAtTwelveAll)));
 			tournament.AddEvent(Event.Create(EventType.WomensSingles, 128, 32, new MatchFormat(3, SetType.TieBreakAtTwelveAll)));
@@ -126,6 +129,14 @@ namespace TournamentManagement.Console
 			using var context = new TournamentManagementDbContext(connectionString, useConsoleLogger);
 			var tournament = context.Tournaments
 				.Include(t => t.Events)
+				.First(t => t.Id == new TournamentId(tournamentGuid));
+		}
+
+		private static void ReadTournamentAndVenue(string connectionString, bool useConsoleLogger, Guid tournamentGuid)
+		{
+			using var context = new TournamentManagementDbContext(connectionString, useConsoleLogger);
+			var tournament = context.Tournaments
+				.Include(t => t.Venue)
 				.First(t => t.Id == new TournamentId(tournamentGuid));
 		}
 

--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
@@ -75,12 +75,9 @@ namespace TournamentManagement.Data
 				p.Property(pp => pp.StartDate).HasColumnName("StartDate");
 				p.Property(pp => pp.EndDate).HasColumnName("EndDate");
 			});
-			builder.HasOne<Venue>()
-				.WithMany()
-				.HasForeignKey(p => p.VenueId);
-			builder.Property(p => p.VenueId)
-				.HasConversion(p => p.Id, p => new VenueId(p));
-			  
+
+			builder.HasOne(p => p.Venue).WithMany();
+
 			builder.HasMany(b => b.Events).WithOne()
 				.Metadata.PrincipalToDependent.SetPropertyAccessMode(PropertyAccessMode.Field);
 		}

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
@@ -22,7 +22,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			tournament.State.Should().Be(TournamentState.BeingDefined);
 			tournament.StartDate.Should().Be(new DateTime(2019, 7, 1));
 			tournament.EndDate.Should().Be(new DateTime(2019, 7, 14));
-			tournament.VenueId.Id.Should().NotBe(Guid.Empty);
+			tournament.Venue.Name.Should().Be("Roland Garros");
 		}
 
 		[Theory]
@@ -31,8 +31,9 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		[InlineData("")]
 		public void CannotCreateTournamentWithEmptyTitle(string title)
 		{
+			var venue = Venue.Create(new VenueId(), "Roland Garros", Surface.Clay);
 			Action act = () => Tournament.Create(title, TournamentLevel.Masters125,
-				new DateTime(2019, 7, 1), new DateTime(2019, 7, 14), new VenueId());
+				new DateTime(2019, 7, 1), new DateTime(2019, 7, 14), venue);
 
 			act.Should()
 				.Throw<ArgumentException>()
@@ -322,8 +323,10 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 		private static Tournament CreateTestTournament()
 		{
+			var venue = Venue.Create(new VenueId(), "Roland Garros", Surface.Clay);
+
 			return Tournament.Create("Wimbledon", TournamentLevel.GrandSlam,
-				new DateTime(2019, 7, 1), new DateTime(2019, 7, 14), new VenueId());
+				new DateTime(2019, 7, 1), new DateTime(2019, 7, 14), venue);
 		}
 
 		private static Event CreateTestEvent(EventType eventtype = EventType.MensSingles)

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -13,7 +13,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		public TournamentDates Dates { get; private set; }
 		public TournamentState State { get; private set; }
 		public TournamentLevel Level { get; private set; }
-		public VenueId VenueId { get; private set; }
+		public Venue Venue { get; private set; }
 
 		public int Year => Dates.Year;
 		public DateTime StartDate => Dates.StartDate;
@@ -22,16 +22,12 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		private readonly List<Event> _events = new();
 		public virtual IReadOnlyList<Event> Events => _events.ToList();
 
-		protected Tournament()
-		{
-		}
-
 		private Tournament(TournamentId id) : base(id)
 		{
 		}
 
 		public static Tournament Create(string title, TournamentLevel level,
-			DateTime startDate, DateTime endDate, VenueId venueId)
+			DateTime startDate, DateTime endDate, Venue venue)
 		{
 			Guard.Against.NullOrWhiteSpace(title, nameof(title));
 
@@ -41,7 +37,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 				Level = level,
 				State = TournamentState.BeingDefined,
 				Dates = new TournamentDates(startDate, endDate),
-				VenueId = venueId
+				Venue = venue
 			};
 
 			return tournament;


### PR DESCRIPTION
In order to help with separation of concerns, and to make sure the Domain Model has better ignorance of persistence concerns, the VenueID on Tournament is changed to ne a Venue navigation property.

(There are a number of other places in the Domain Model to apply this to - that will be done later)