### PR TITLE
Enable Lazy Loading to ensure no partially initialised entities

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagement.Data.csproj
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagement.Data.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.13" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>

--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
@@ -37,7 +37,8 @@ namespace TournamentManagement.Data
 			});
 
 			optionsBuilder
-				.UseSqlServer(_connectionString);
+				.UseSqlServer(_connectionString)
+				.UseLazyLoadingProxies();
 
 			if (_useConsoleLogger)
 			{

--- a/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
@@ -14,6 +14,10 @@ namespace TournamentManagement.Domain.PlayerAggregate
 		public ushort DoublesRank { get; private set; }
 		public Gender Gender { get; private set; }
 
+		protected Player()
+		{
+		}
+
 		private Player(PlayerId id) : base(id)
 		{
 		}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
@@ -15,9 +15,13 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		public EventSize EventSize { get; private set; }
 		public bool IsCompleted { get; private set; }
 
-		public ReadOnlyCollection<EventEntry> Entries { get; private set; }
+		public virtual ReadOnlyCollection<EventEntry> Entries { get; private set; }
 
 		private readonly IList<EventEntry> _entries;
+
+		protected Event()
+		{
+		}
 
 		private Event(EventId id) : base(id)
 		{

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventEntry.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventEntry.cs
@@ -17,6 +17,10 @@ namespace TournamentManagement.Domain.TournamentAggregate
 
 		private readonly IList<Player> _players;
 
+		protected EventEntry()
+		{
+		}
+
 		private EventEntry(EventEntryId id) : base(id)
 		{
 			_players = new List<Player>();

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -13,7 +13,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		public TournamentDates Dates { get; private set; }
 		public TournamentState State { get; private set; }
 		public TournamentLevel Level { get; private set; }
-		public Venue Venue { get; private set; }
+		public virtual Venue Venue { get; private set; }
 
 		public int Year => Dates.Year;
 		public DateTime StartDate => Dates.StartDate;
@@ -21,6 +21,10 @@ namespace TournamentManagement.Domain.TournamentAggregate
 
 		private readonly List<Event> _events = new();
 		public virtual IReadOnlyList<Event> Events => _events.ToList();
+
+		protected Tournament()
+		{
+		}
 
 		private Tournament(TournamentId id) : base(id)
 		{

--- a/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Court.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Court.cs
@@ -14,6 +14,10 @@ namespace TournamentManagement.Domain.VenueAggregate
 		public string Name { get; private set; }
 		public int Capacity { get; private set; }
 
+		protected Court()
+		{
+		}
+
 		private Court(CourtId id) : base(id)
 		{
 		}


### PR DESCRIPTION
Following the principal that entities mush not be partially loaded - Make sure the navigation properties of Tournament, Entity, Player, Venue and Court are enabled for Lazy loading.