### PR TITLE
Introduce Venue Repository to solve EF issue with lazy loading

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Application/Repository/IVenueRepository.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/Repository/IVenueRepository.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using TournamentManagement.Domain.VenueAggregate;
+
+namespace TournamentManagement.Application.Repository
+{
+	public interface IVenueRepository : IDisposable
+	{
+		Venue GetById(VenueId id);
+		void Add(Venue venue);
+		void SaveChanges();
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Data/Repository/VenueRepository.cs
+++ b/src/TournamentManagement/TournamentManagement.Data/Repository/VenueRepository.cs
@@ -1,0 +1,40 @@
+﻿using TournamentManagement.Application.Repository;
+using TournamentManagement.Domain.VenueAggregate;
+
+namespace TournamentManagement.Data.Repository
+{
+	public class VenueRepository : IVenueRepository
+	{
+		private readonly TournamentManagementDbContext _context;
+
+		public VenueRepository(TournamentManagementDbContext context)
+		{
+			_context = context;
+		}
+
+		public Venue GetById(VenueId id)
+		{
+			var venue = _context.Venues.Find(id);
+			if (venue == null) return null;
+
+			_context.Entry(venue).Collection(x => x.Courts).Load();
+
+			return venue;
+		}
+
+		public void Add(Venue venue)
+		{
+			_context.Venues.Add(venue);
+		}
+
+		public void SaveChanges()
+		{
+			_context.SaveChanges();
+		}
+
+		public void Dispose()
+		{
+			_context.Dispose();
+		}
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagement.Data.csproj
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagement.Data.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Common\DomainDesign.Common\DomainDesign.Common.csproj" />
+    <ProjectReference Include="..\TournamentManagement.Application\TournamentManagement.Application.csproj" />
     <ProjectReference Include="..\TournamentManagement.Domain\TournamentManagement.Domain.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
EF only does Lazy Loading when you access a Property, and not when you access
backing fields directly. We have some logic that relies on the backing field being
populated. So we have to use eager loading. So introduced a repository to take care
of the eager loading.
Also had a tidy up in Program.cs and made it use the new VenueRepository.