### PR TITLE
Fix two issues in domain when being read from database

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Console/Program.cs
+++ b/src/TournamentManagement/TournamentManagement.Console/Program.cs
@@ -258,7 +258,8 @@ namespace TournamentManagement.Console
 			using var context = new TournamentManagementDbContext(_connectionString, _useConsoleLogger);
 			var roundRepo = new RoundRepository(context);
 			var round = roundRepo.GetById(roundId);
-			var title = round.Tournament.Title;
+			var tournamentTitle = round.Tournament.Title;
+			var roundTitle = round.Title;
 		}
 
 		private static string GetConnectionString()

--- a/src/TournamentManagement/TournamentManagement.Console/Program.cs
+++ b/src/TournamentManagement/TournamentManagement.Console/Program.cs
@@ -36,8 +36,10 @@ namespace TournamentManagement.Console
 			var courtId = AddAnExtraCourt(venueId);
 			RemoveCourt(venueId, courtId);
 
-			var tournamentId = CreateTournament(venueId);
+			var playerId = new PlayerId();
+			var tournamentId = CreateTournament(venueId, playerId);
 			TestDuplicateEventTypes(tournamentId);
+			TestAddingPlayersUsesLazyLoading(tournamentId, playerId);
 			ReadTournamentAndCloseEntries(tournamentId);
 			ReadEntries(tournamentId);
 
@@ -144,7 +146,7 @@ namespace TournamentManagement.Console
 			context.SaveChanges();
 		}
 
-		private static TournamentId CreateTournament(VenueId venueId)
+		private static TournamentId CreateTournament(VenueId venueId, PlayerId playerId)
 		{
 			using var context = new TournamentManagementDbContext(_connectionString, _useConsoleLogger);
 			var tournamentRepo = new TournamentRepository(context);
@@ -162,7 +164,7 @@ namespace TournamentManagement.Console
 
 			tournament.OpenForEntries();
 
-			var player = Player.Register(new PlayerId(), "Edward Entered", 12, 123, Gender.Male);
+			var player = Player.Register(playerId, "Edward Entered", 12, 123, Gender.Male);
 			tournament.EnterEvent(EventType.MensSingles, player);
 
 			tournamentRepo.Add(tournament);
@@ -183,6 +185,23 @@ namespace TournamentManagement.Console
 				tournament.AddEvent(Event.Create(EventType.MensSingles, 128, 32,
 					new MatchFormat(5, SetType.TieBreakAtTwelveAll)));
 				context.SaveChanges();
+			}
+			catch
+			{
+				// Do nothing - just proving a point
+			}
+		}
+
+		private static void TestAddingPlayersUsesLazyLoading(TournamentId tournamentId, PlayerId playerId)
+		{
+			using var context = new TournamentManagementDbContext(_connectionString, _useConsoleLogger);
+			var repository = new TournamentRepository(context);
+
+			var tournament = repository.GetById(tournamentId);
+
+			try
+			{
+				tournament.EnterEvent(EventType.MensSingles, Player.Register(playerId, "Someone Else", 1, 1, Gender.Male));
 			}
 			catch
 			{

--- a/src/TournamentManagement/TournamentManagement.Domain/RoundAggregate/Round.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/RoundAggregate/Round.cs
@@ -11,8 +11,8 @@ namespace TournamentManagement.Domain.RoundAggregate
 		public virtual Tournament Tournament { get; private set; }
 		public EventType EventType { get; private set; }
 		public int RoundNumber { get; private set; }
-		public string Title { get; private set; }
 		public int CompetitorCount { get; private set; }
+		public string Title => GetRoundTitle();
 
 		protected Round()
 		{
@@ -34,19 +34,18 @@ namespace TournamentManagement.Domain.RoundAggregate
 				Tournament = tournament,
 				EventType = eventType,
 				RoundNumber = roundNumber,
-				Title = GetRoundTitle(competitorCount),
 				CompetitorCount = competitorCount
 			};
 
 			return round;
 		}
 
-		private static string GetRoundTitle(int playerCount)
+		private string GetRoundTitle()
 		{
-			if (playerCount == 2) return "Final";
-			if (playerCount == 4) return "Semi-Final";
-			if (playerCount == 8) return "Quarter-Final";
-			return $"Round of {playerCount}";
+			if (CompetitorCount == 2) return "Final";
+			if (CompetitorCount == 4) return "Semi-Final";
+			if (CompetitorCount == 8) return "Quarter-Final";
+			return $"Round of {CompetitorCount}";
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
@@ -58,7 +58,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			if (SinglesEvent)
 			{
 				Guard.Against.Null(playerOne, nameof(playerOne));
-				Guard.Against.PlayerAlreadyEnteredInSingleEvent(_entries, playerOne);
+				Guard.Against.PlayerAlreadyEnteredInSingleEvent(Entries, playerOne);
 
 				entry = EventEntry.CreateSinglesEventEntry(EventType, playerOne);
 			}
@@ -66,7 +66,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			{
 				Guard.Against.Null(playerOne, nameof(playerOne));
 				Guard.Against.Null(playerTwo, nameof(playerTwo));
-				Guard.Against.PlayersAlreadyEnteredInDoublesEvent(_entries, playerOne, playerTwo);
+				Guard.Against.PlayersAlreadyEnteredInDoublesEvent(Entries, playerOne, playerTwo);
 
 				entry = EventEntry.CreateDoublesEventEntry(EventType, playerOne, playerTwo);
 			}
@@ -79,7 +79,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			if (SinglesEvent)
 			{
 				Guard.Against.Null(playerOne, nameof(playerOne));
-				var entry = Guard.Against.PlayerNotEnteredInSingleEvent(_entries, playerOne);
+				var entry = Guard.Against.PlayerNotEnteredInSingleEvent(Entries, playerOne);
 
 				_entries.Remove(entry);
 			}
@@ -87,7 +87,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			{
 				Guard.Against.Null(playerOne, nameof(playerOne));
 				Guard.Against.Null(playerTwo, nameof(playerTwo));
-				var entry = Guard.Against.PlayersNotEnteredInDoublesEvent(_entries, playerOne, playerTwo);
+				var entry = Guard.Against.PlayersNotEnteredInDoublesEvent(Entries, playerOne, playerTwo);
 
 				_entries.Remove(entry);
 			}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Guards/EventGuards.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Guards/EventGuards.cs
@@ -17,7 +17,7 @@ namespace TournamentManagement.Domain.TournamentAggregate.Guards
 		}
 
 		public static void PlayerAlreadyEnteredInSingleEvent(this IGuardClause guardClause,
-			List<EventEntry> entries, Player player)
+			IEnumerable<EventEntry> entries, Player player)
 		{
 			var existingPlayerIds = entries.Select(e => e.PlayerOne.Id);
 			if (existingPlayerIds.Any(p => p == player.Id))
@@ -27,7 +27,7 @@ namespace TournamentManagement.Domain.TournamentAggregate.Guards
 		}
 
 		public static void PlayersAlreadyEnteredInDoublesEvent(this IGuardClause guardClause,
-			List<EventEntry> entries, Player playerOne, Player playerTwo)
+			IEnumerable<EventEntry> entries, Player playerOne, Player playerTwo)
 		{
 			var existingPlayerIds = entries.Select(e => e.PlayerOne.Id)
 				.Union(entries.Select(e => e.PlayerTwo.Id));
@@ -43,9 +43,9 @@ namespace TournamentManagement.Domain.TournamentAggregate.Guards
 		}
 
 		public static EventEntry PlayerNotEnteredInSingleEvent(this IGuardClause guardClause,
-			List<EventEntry> entries, Player playerOne)
+			IEnumerable<EventEntry> entries, Player playerOne)
 		{
-			var entry = entries.Find(e => e.PlayerOne == playerOne);
+			var entry = entries.FirstOrDefault(e => e.PlayerOne == playerOne);
 			if (entry == null)
 			{
 				throw new Exception("Player was not entered into the event");
@@ -54,9 +54,9 @@ namespace TournamentManagement.Domain.TournamentAggregate.Guards
 		}
 
 		public static EventEntry PlayersNotEnteredInDoublesEvent(this IGuardClause guardClause,
-			List<EventEntry> entries, Player playerOne, Player playerTwo)
+			IEnumerable<EventEntry> entries, Player playerOne, Player playerTwo)
 		{
-			var entry = entries.Find(e => e.PlayerOne == playerOne && e.PlayerTwo == playerTwo);
+			var entry = entries.FirstOrDefault(e => e.PlayerOne == playerOne && e.PlayerTwo == playerTwo);
 			if (entry == null)
 			{
 				throw new Exception("Players were not entered into the event");


### PR DESCRIPTION
Issue 1 - The Title of a Round is not being calculated when read from the database and hence not constructed from the Factory.

Issue 2 - Making sure the _entries collection are populated when the Event is read from the database. Compromised and went against recommendation and used the Property to get EF to lazy load the collection. Bad: persistence concerns have leaked into the domain, and possible cause of bugs (using the backing filed and not having the collection loaded). But it seems waste to load all the Entries every time we just want to load the Tournament.