### PR TITLE
Tournament creates Event rather that it being passed in

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Console/Program.cs
+++ b/src/TournamentManagement/TournamentManagement.Console/Program.cs
@@ -157,10 +157,8 @@ namespace TournamentManagement.Console
 			var tournament = Tournament.Create("Wimbledon 2022", TournamentLevel.GrandSlam,
 				new DateTime(2022, 07, 22), new DateTime(2022, 07, 29), venue);
 
-			tournament.AddEvent(Event.Create(EventType.MensSingles, 128, 32,
-				new MatchFormat(5, SetType.TieBreakAtTwelveAll)));
-			tournament.AddEvent(Event.Create(EventType.WomensSingles, 128, 32,
-				new MatchFormat(3, SetType.TieBreakAtTwelveAll)));
+			tournament.AddEvent(EventType.MensSingles, 128, 32, 5, SetType.TieBreakAtTwelveAll);
+			tournament.AddEvent(EventType.WomensSingles, 128, 32, 3, SetType.TieBreakAtTwelveAll);
 
 			tournament.OpenForEntries();
 
@@ -182,8 +180,7 @@ namespace TournamentManagement.Console
 
 			try
 			{
-				tournament.AddEvent(Event.Create(EventType.MensSingles, 128, 32,
-					new MatchFormat(5, SetType.TieBreakAtTwelveAll)));
+				tournament.AddEvent(EventType.MensSingles, 128, 32, 5, SetType.TieBreakAtTwelveAll);
 				context.SaveChanges();
 			}
 			catch

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
@@ -107,11 +107,11 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanAddAnEventToATournament()
 		{
 			var tournament = CreateTestTournament();
-			var tennisEvent = CreateTestEvent();
 
-			tournament.AddEvent(tennisEvent);
+			tournament.AddEvent(EventType.MensSingles, 128, 32, 3, SetType.TieBreak);
+			tournament.AddEvent(EventType.WomensSingles, 128, 32, MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
-			tournament.Events.Count.Should().Be(1);
+			tournament.Events.Count.Should().Be(2);
 			tournament.Events[0].EventSize.EntrantsLimit.Should().Be(128);
 		}
 
@@ -119,11 +119,11 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanAddAllTypesOfEventToATournament()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
-			tournament.AddEvent(CreateTestEvent(EventType.MensDoubles));
-			tournament.AddEvent(CreateTestEvent(EventType.WomensDoubles));
-			tournament.AddEvent(CreateTestEvent(EventType.MixedDoubles));
+			AddEventToTournament(tournament, EventType.MensSingles);
+			AddEventToTournament(tournament, EventType.WomensSingles);
+			AddEventToTournament(tournament, EventType.MensDoubles);
+			AddEventToTournament(tournament, EventType.WomensDoubles);
+			AddEventToTournament(tournament, EventType.MixedDoubles);
 
 			tournament.Events.Count.Should().Be(5);
 		}
@@ -132,8 +132,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanGetAnEventFromTournamentByEventType()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
+			AddEventToTournament(tournament, EventType.MensSingles);
+			AddEventToTournament(tournament, EventType.WomensSingles);
 
 			var tennisEvent = tournament.GetEvent(EventType.WomensSingles);
 
@@ -144,8 +144,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannotGetAnEventFromTournamentIfEventDoesNotExist()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
+			AddEventToTournament(tournament, EventType.MensSingles);
+			AddEventToTournament(tournament, EventType.WomensSingles);
 
 			Action act = () => tournament.GetEvent(EventType.MixedDoubles);
 
@@ -157,8 +157,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanRemoveAnEventFromATournament()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
+			AddEventToTournament(tournament, EventType.MensSingles);
+			AddEventToTournament(tournament, EventType.WomensSingles);
 
 			tournament.Events.Count.Should().Be(2);
 
@@ -172,9 +172,9 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannnotAddASecondEventOfTheSameTypeToATournament()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			AddEventToTournament(tournament, EventType.MensSingles);
 
-			Action act = () => tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			Action act = () => AddEventToTournament(tournament, EventType.MensSingles);
 
 			act.Should()
 				.Throw<Exception>()
@@ -185,7 +185,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannotRemoveAnEventFromATournamentIfTheEventDoesNotExist()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			AddEventToTournament(tournament, EventType.MensSingles);
 
 			tournament.Events.Count.Should().Be(1);
 
@@ -200,9 +200,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanClearAllEventsForTheTournament()
 		{
 			var tournament = CreateTestTournament();
-
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
+			AddEventToTournament(tournament, EventType.MensSingles);
+			AddEventToTournament(tournament, EventType.WomensSingles);
 
 			tournament.Events.Count.Should().Be(2);
 
@@ -212,50 +211,11 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		}
 
 		[Fact]
-		public void CanAddACollectionOfEventsToATournamment()
-		{
-			var tournament = CreateTestTournament();
-
-			var events = new List<Event>()
-			{
-				CreateTestEvent(EventType.MensSingles),
-				CreateTestEvent(EventType.WomensSingles),
-				CreateTestEvent(EventType.MensDoubles),
-				CreateTestEvent(EventType.WomensDoubles),
-				CreateTestEvent(EventType.MixedDoubles)
-			};
-
-			tournament.SetEvents(events);
-
-			tournament.Events.Count.Should().Be(5);
-		}
-
-		[Fact]
-		public void CannotAddACollectionOfEventsToATournammentIfTwoHaveTheSameType()
-		{
-			var tournament = CreateTestTournament();
-
-			var events = new List<Event>()
-			{
-				CreateTestEvent(EventType.MensSingles),
-				CreateTestEvent(EventType.MensSingles)
-			};
-
-			Action act = () => tournament.SetEvents(events);
-
-			act.Should()
-				.Throw<Exception>()
-				.WithMessage("Tournament already has an event of type MensSingles");
-
-			tournament.Events.Count.Should().Be(0);
-		}
-
-		[Fact]
 		public void CanTransitionThroughTheStatesOfATournament()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
-			tournament.AddEvent(CreateTestEvent(EventType.WomensSingles));
+			AddEventToTournament(tournament, EventType.MensSingles);
+			AddEventToTournament(tournament, EventType.WomensSingles);
 
 			tournament.OpenForEntries();
 			tournament.State.Should().Be(TournamentState.AcceptingEntries);
@@ -292,9 +252,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannotAddEventIfTournamentIsNotInBeingDefinedState()
 		{
 			var tournament = CreateTestTournamentAndOpenForEntries();
-			var tennisEvent = CreateTestEvent(EventType.WomensSingles);
 
-			void act() => tournament.AddEvent(tennisEvent);
+			void act() => AddEventToTournament(tournament);
 
 			VerifyExceptionThrownWhenNotInCorrectState(act, "AddEvent", TournamentState.AcceptingEntries);
 		}
@@ -317,16 +276,6 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			void act() => tournament.ClearEvents();
 
 			VerifyExceptionThrownWhenNotInCorrectState(act, "ClearEvents", TournamentState.AcceptingEntries);
-		}
-
-		[Fact]
-		public void CannotSetEventsIfTournamentIsNotInBeingDefinedState()
-		{
-			var tournament = CreateTestTournamentAndOpenForEntries();
-
-			void act() => tournament.SetEvents(null);
-
-			VerifyExceptionThrownWhenNotInCorrectState(act, "SetEvents", TournamentState.AcceptingEntries);
 		}
 
 		[Fact]
@@ -390,8 +339,8 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CanEnterAnDoublesEventWithTwoPlayers()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(Event.Create(EventType.MensSingles, 128, 32, MatchFormat.ThreeSetMatchWithFinalSetTieBreak));
-			tournament.AddEvent(Event.Create(EventType.MensDoubles, 64, 16, MatchFormat.ThreeSetMatchWithFinalSetTieBreak));
+			AddEventToTournament(tournament, EventType.MensSingles);
+			AddEventToTournament(tournament, EventType.MensDoubles);
 			tournament.OpenForEntries();
 
 			var playerOne = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
@@ -424,7 +373,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void PairOfPlayersCanWithdrawFromDoublesEvent()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(Event.Create(EventType.MensDoubles, 128, 32, MatchFormat.ThreeSetMatchWithFinalSetTieBreak));
+			AddEventToTournament(tournament, EventType.MensDoubles);
 			tournament.OpenForEntries();
 			var playerOne = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
 			var playerTwo = Player.Register(new PlayerId(), "Steve Serve", 15, 100, Gender.Male);
@@ -447,7 +396,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		public void CannotWithdrawPlayersIfTournamentIsNotInOpenForEntriesState()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			AddEventToTournament(tournament, EventType.MensSingles);
 			var player = Player.Register(new PlayerId(), "Steve Serve", 1, 1, Gender.Male);
 
 			Action act = () => tournament.WithdrawFromEvent(EventType.MensSingles, player);
@@ -516,15 +465,15 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 				new DateTime(2019, 7, 1), new DateTime(2019, 7, 14), venue);
 		}
 
-		private static Event CreateTestEvent(EventType eventtype = EventType.MensSingles)
+		private static void AddEventToTournament(Tournament tournament, EventType eventType = EventType.MensSingles)
 		{
-			return Event.Create(eventtype, 128, 32, MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
+			tournament.AddEvent(eventType, 128, 32, 3, SetType.TieBreak);
 		}
 
 		private static Tournament CreateTestTournamentAndOpenForEntries()
 		{
 			var tournament = CreateTestTournament();
-			tournament.AddEvent(CreateTestEvent(EventType.MensSingles));
+			AddEventToTournament(tournament);
 			tournament.OpenForEntries();
 			return tournament;
 		}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
@@ -2,9 +2,12 @@
 using DomainDesign.Common;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate.Guards;
+
+[assembly: InternalsVisibleTo("TournamentManagement.Domain.UnitTests")]
 
 namespace TournamentManagement.Domain.TournamentAggregate
 {
@@ -27,7 +30,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		{
 		}
 
-		public static Event Create(EventType eventType, int entrantsLimit,
+		internal static Event Create(EventType eventType, int entrantsLimit,
 			int numberOfSeeds, MatchFormat matchFormat)
 		{
 			var tennisEvent = new Event(new EventId());
@@ -51,7 +54,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			IsCompleted = true;
 		}
 
-		public void EnterEvent(Player playerOne, Player playerTwo = null)
+		internal void EnterEvent(Player playerOne, Player playerTwo = null)
 		{
 			EventEntry entry;
 
@@ -74,7 +77,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			_entries.Add(entry);
 		}
 
-		public void WithdrawFromEvent(Player playerOne, Player playerTwo = null)
+		internal void WithdrawFromEvent(Player playerOne, Player playerTwo = null)
 		{
 			if (SinglesEvent)
 			{

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
@@ -2,12 +2,9 @@
 using DomainDesign.Common;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate.Guards;
-
-[assembly: InternalsVisibleTo("TournamentManagement.Domain.UnitTests")]
 
 namespace TournamentManagement.Domain.TournamentAggregate
 {

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventEntry.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventEntry.cs
@@ -21,7 +21,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		{
 		}
 
-		public static EventEntry CreateSinglesEventEntry(EventType eventType, Player player)
+		internal static EventEntry CreateSinglesEventEntry(EventType eventType, Player player)
 		{
 			Guard.Against.NotASinglesEventType(eventType);
 			Guard.Against.WrongGenderForEventType(eventType, new List<Player> { player });
@@ -36,7 +36,7 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			return entry;
 		}
 
-		public static EventEntry CreateDoublesEventEntry(EventType eventType,
+		internal static EventEntry CreateDoublesEventEntry(EventType eventType,
 			Player playerOne, Player playerTwo)
 		{
 			Guard.Against.NotADoublesEventType(eventType);

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -3,9 +3,12 @@ using DomainDesign.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.VenueAggregate;
+
+[assembly: InternalsVisibleTo("TournamentManagement.Domain.UnitTests")]
 
 namespace TournamentManagement.Domain.TournamentAggregate
 {

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -3,6 +3,7 @@ using DomainDesign.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.VenueAggregate;
 
@@ -68,10 +69,19 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			return tennisEvent;
 		}
 
-		public void AddEvent(Event tennisEvent)
+		public void AddEvent(EventType eventType, int entrantsLimit, int numberOfSeeds,
+			int numberOfSets, SetType finalSetType)
+		{
+			var matchFormat = new MatchFormat(numberOfSets, finalSetType);
+			AddEvent(eventType, entrantsLimit, numberOfSeeds, matchFormat);
+		}
+
+		public void AddEvent(EventType eventType, int entrantsLimit, int numberOfSeeds, MatchFormat matchFormat)
 		{
 			Guard.Against.TournamentActionInWrongState(TournamentState.BeingDefined, State, nameof(AddEvent));
-			Guard.Against.DuplicateEventType(_events, tennisEvent.EventType); 
+			Guard.Against.DuplicateEventType(_events, eventType);
+
+			var tennisEvent = Event.Create(eventType, entrantsLimit, numberOfSeeds, matchFormat);
 
 			_events.Add(tennisEvent);
 		}
@@ -91,26 +101,6 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			_events.Clear();
 		}
 
-		public void SetEvents(IEnumerable<Event> events)
-		{
-			Guard.Against.TournamentActionInWrongState(TournamentState.BeingDefined, State, nameof(SetEvents));
-
-			_events.Clear();
-
-			try
-			{
-				foreach (var tennisEvent in events)
-				{
-					Guard.Against.DuplicateEventType(_events, tennisEvent.EventType);
-					_events.Add(tennisEvent);
-				}
-			}
-			catch (Exception)
-			{
-				_events.Clear();
-				throw;
-			}
-		}
 
 		public void OpenForEntries()
 		{

--- a/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Court.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Court.cs
@@ -1,8 +1,5 @@
 ﻿using Ardalis.GuardClauses;
 using DomainDesign.Common;
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("TournamentManagement.Domain.UnitTests")]
 
 namespace TournamentManagement.Domain.VenueAggregate
 {


### PR DESCRIPTION
Rather than the client create the Event objects and pass them to the Tournament when adding events to a Tournament, let the Tournament create the Event object from parameters passed in.

Then we can hide a number of methods from client code (making them internal) - the client has to go through the aggregate root