### PR TITLE
Domain events

### DIFF
--- a/src/Common/DomainDesign.Common/AggregateRoot.cs
+++ b/src/Common/DomainDesign.Common/AggregateRoot.cs
@@ -2,7 +2,13 @@
 
 namespace DomainDesign.Common
 {
-	public abstract class AggregateRoot<T> : Entity<T>
+	public interface IAggregateRoot
+	{
+		IReadOnlyList<IDomainEvent> DomainEvents { get; }
+		void ClearDomainEvents();
+	}
+
+	public abstract class AggregateRoot<T> : Entity<T>, IAggregateRoot
 	{
 		private readonly List<IDomainEvent> _domainEvents = new();
 		public IReadOnlyList<IDomainEvent> DomainEvents => _domainEvents;
@@ -12,7 +18,7 @@ namespace DomainDesign.Common
 			_domainEvents.Add(domainEvent);
 		}
 
-		protected void ClearDomainEvents()
+		public void ClearDomainEvents()
 		{
 			_domainEvents.Clear();
 		}

--- a/src/Common/DomainDesign.Common/AggregateRoot.cs
+++ b/src/Common/DomainDesign.Common/AggregateRoot.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace DomainDesign.Common
+{
+	public abstract class AggregateRoot<T> : Entity<T>
+	{
+		private readonly List<IDomainEvent> _domainEvents = new();
+		public IReadOnlyList<IDomainEvent> DomainEvents => _domainEvents;
+
+		protected void RaiseDomainEvent(IDomainEvent domainEvent)
+		{
+			_domainEvents.Add(domainEvent);
+		}
+
+		protected void ClearDomainEvents()
+		{
+			_domainEvents.Clear();
+		}
+
+		protected AggregateRoot(T id) : base(id)
+		{
+		}
+
+		protected AggregateRoot()
+		{
+		}
+	}
+}

--- a/src/Common/DomainDesign.Common/IDomainEvent.cs
+++ b/src/Common/DomainDesign.Common/IDomainEvent.cs
@@ -1,6 +1,6 @@
 ﻿namespace DomainDesign.Common
 {
-	public interface IAggregateRoot
+	public interface IDomainEvent
 	{
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
+++ b/src/TournamentManagement/TournamentManagement.Data/TournamentManagementDbContext.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using DomainDesign.Common;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using TournamentManagement.Data.Configuration;
 using TournamentManagement.Domain.CompetitorAggregate;
 using TournamentManagement.Domain.PlayerAggregate;
@@ -58,6 +62,25 @@ namespace TournamentManagement.Data
 			new CourtEntityTypeConfiguration().Configure(modelBuilder.Entity<Court>());
 			new CompetitorEntityTypeConfiguration().Configure(modelBuilder.Entity<Competitor>());
 			new RoundEntityTypeConfiguration().Configure(modelBuilder.Entity<Round>());
+		}
+
+		public override int SaveChanges()
+		{
+			List<IAggregateRoot> aggregateRoots = ChangeTracker
+				.Entries()
+				.Where(x => x.Entity is IAggregateRoot)
+				.Select(x => (IAggregateRoot)x.Entity)
+				.ToList();
+
+			int result = base.SaveChanges();
+
+			foreach(IAggregateRoot aggregateRoot in aggregateRoots)
+			{
+				Console.WriteLine($"Dispatching {aggregateRoot.DomainEvents.Count} Events for Aggregate Root of type {aggregateRoot.GetType()}");
+				aggregateRoot.ClearDomainEvents();
+			}
+
+			return result;
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CompetitorAggregate/CompetitorTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CompetitorAggregate/CompetitorTests.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using System;
-using System.Collections.Generic;
 using TournamentManagement.Domain.CompetitorAggregate;
 using TournamentManagement.Domain.TournamentAggregate;
 using TournamentManagement.Domain.VenueAggregate;

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
@@ -454,7 +454,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			void act() => tournament.CompleteEvent(EventType.MensSingles);
 
-			VerifyExceptionThrownWhenNotInCorrectState(act, "EventCompleted", tournament.State);
+			VerifyExceptionThrownWhenNotInCorrectState(act, "CompleteEvent", tournament.State);
 		}
 
 		private static Tournament CreateTestTournament()

--- a/src/TournamentManagement/TournamentManagement.Domain/CompetitorAggregate/Competitor.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/CompetitorAggregate/Competitor.cs
@@ -4,7 +4,7 @@ using TournamentManagement.Domain.TournamentAggregate;
 
 namespace TournamentManagement.Domain.CompetitorAggregate
 {
-	public class Competitor : Entity<CompetitorId>, IAggregateRoot
+	public class Competitor : AggregateRoot<CompetitorId>
 	{
 		public virtual Tournament Tournament { get; private set; }
 		public EventType EventType { get; private set; }

--- a/src/TournamentManagement/TournamentManagement.Domain/MatchAggregate/Match.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/MatchAggregate/Match.cs
@@ -9,7 +9,7 @@ using TournamentManagement.Domain.CompetitorAggregate;
 
 namespace TournamentManagement.Domain.MatchAggregate
 {
-	public class Match : Entity<MatchId>, IAggregateRoot
+	public class Match : AggregateRoot<MatchId>
 	{
 		public MatchFormat Format { get; private set; }
 		public MatchState State { get; private set; }

--- a/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
@@ -4,7 +4,7 @@ using TournamentManagement.Common;
 
 namespace TournamentManagement.Domain.PlayerAggregate
 {
-	public class Player : Entity<PlayerId>, IAggregateRoot
+	public class Player : AggregateRoot<PlayerId>
 	{
 		private const ushort MinRank = 1;
 		private const ushort MaxRank = 9999;

--- a/src/TournamentManagement/TournamentManagement.Domain/RoundAggregate/Round.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/RoundAggregate/Round.cs
@@ -4,7 +4,7 @@ using TournamentManagement.Domain.TournamentAggregate;
 
 namespace TournamentManagement.Domain.RoundAggregate
 {
-	public class Round : Entity<RoundId>, IAggregateRoot
+	public class Round : AggregateRoot<RoundId>
 	{
 		private static readonly int[] AllowedCompetitorCount = { 128, 64, 32, 16, 8, 4 ,2 };
 

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Events/TournamentEntryClosed.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Events/TournamentEntryClosed.cs
@@ -1,0 +1,14 @@
+﻿using DomainDesign.Common;
+
+namespace TournamentManagement.Domain.TournamentAggregate.Events
+{
+	public sealed class TournamentEntryClosed : IDomainEvent
+	{
+		public TournamentId TournamentId { get; }
+
+		public TournamentEntryClosed(TournamentId tournamentId)
+		{
+			TournamentId = tournamentId;
+		}
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Events/TournamentEntryOpened.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Events/TournamentEntryOpened.cs
@@ -1,0 +1,17 @@
+﻿using DomainDesign.Common;
+using System.Collections.Generic;
+
+namespace TournamentManagement.Domain.TournamentAggregate.Events
+{
+	public sealed class TournamentEntryOpened : IDomainEvent
+	{
+		public TournamentId TournamentId { get; }
+		public IEnumerable<EventType> EventTypes { get; }
+
+		public TournamentEntryOpened(TournamentId tournamentId, IEnumerable<EventType> eventTypes)
+		{
+			TournamentId = tournamentId;
+			EventTypes = eventTypes;
+		}
+	}
+}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
+using TournamentManagement.Domain.TournamentAggregate.Events;
 using TournamentManagement.Domain.VenueAggregate;
 
 [assembly: InternalsVisibleTo("TournamentManagement.Domain.UnitTests")]
@@ -108,10 +109,9 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		{
 			Guard.Against.TournamentActionInWrongState(TournamentState.BeingDefined, State, nameof(OpenForEntries));
 			Guard.Against.NoEvents(_events);
-			
-			// Raise event to get notifications out to players telling them they can enter
 
 			TransitionToState(TournamentState.AcceptingEntries);
+			RaiseDomainEvent(new TournamentEntryOpened(Id, _events.Select(e => e.EventType)));
 		}
 
 		public void EnterEvent(EventType eventType, Player playerOne, Player playerTwo = null)
@@ -134,16 +134,15 @@ namespace TournamentManagement.Domain.TournamentAggregate
 		{
 			Guard.Against.TournamentActionInWrongState(TournamentState.AcceptingEntries, State, nameof(CloseEntries));
 
-			// Raise event to get notification out to players saying if they are in or not
-
 			TransitionToState(TournamentState.EntriesClosed);
+			RaiseDomainEvent(new TournamentEntryClosed(Id));
 		}
 
 		public void DrawTheEvents()
 		{
 			Guard.Against.TournamentActionInWrongState(TournamentState.EntriesClosed, State, nameof(DrawTheEvents));
 
-			// Raise event to perform the draw for each event
+			// Raise event to perform the draw for each event - or do it ourselves in here
 
 			TransitionToState(TournamentState.DrawComplete);
 		}

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -12,7 +12,7 @@ using TournamentManagement.Domain.VenueAggregate;
 
 namespace TournamentManagement.Domain.TournamentAggregate
 {
-	public class Tournament : Entity<TournamentId>, IAggregateRoot
+	public class Tournament : AggregateRoot<TournamentId>
 	{
 		public string Title { get; private set; }
 		public TournamentDates Dates { get; private set; }

--- a/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Venue.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/VenueAggregate/Venue.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace TournamentManagement.Domain.VenueAggregate
 {
-	public class Venue : Entity<VenueId>, IAggregateRoot
+	public class Venue : AggregateRoot<VenueId>
 	{
 		public string Name { get; private set; }
 		public Surface Surface { get; private set; }


### PR DESCRIPTION
Add an Aggregate Root class that supports raising Domain Events, and make all Aggregate Roots inherit from this abstract class.
Define a couple of Domain Events in the Tournament Aggregate, and get Tournament Aggregate Root to raise them
Provide a minimal implementation of dispatching the events from the DbContext