### PR TITLE
Create TournamentManagement.Common project

### DIFF
--- a/src/Tennis.sln
+++ b/src/Tennis.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TournamentManagement.Consol
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TournamentManagement.Contract", "TournamentManagement\TournamentManagement.Contract\TournamentManagement.Contract.csproj", "{7C634D92-F8CA-4C1D-9E83-C8A8441977FC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TournamentManagement.Common", "TournamentManagement\TournamentManagement.Common\TournamentManagement.Common.csproj", "{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,18 @@ Global
 		{7C634D92-F8CA-4C1D-9E83-C8A8441977FC}.Release|x64.Build.0 = Release|Any CPU
 		{7C634D92-F8CA-4C1D-9E83-C8A8441977FC}.Release|x86.ActiveCfg = Release|Any CPU
 		{7C634D92-F8CA-4C1D-9E83-C8A8441977FC}.Release|x86.Build.0 = Release|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Debug|x86.Build.0 = Debug|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Release|x64.Build.0 = Release|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,6 +171,7 @@ Global
 		{982D6DF5-1950-4340-8E9F-0AB4851694E7} = {32CCE864-ACCA-4912-9C18-EE3FFD706644}
 		{433B56E0-BB90-48DA-B2B4-F2EC377CD1FE} = {32CCE864-ACCA-4912-9C18-EE3FFD706644}
 		{7C634D92-F8CA-4C1D-9E83-C8A8441977FC} = {32CCE864-ACCA-4912-9C18-EE3FFD706644}
+		{DE88D0AC-FD0E-4971-AC74-393B2A1DA754} = {32CCE864-ACCA-4912-9C18-EE3FFD706644}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8A0BBE81-6905-4BD2-86DB-44B6D43B4DEF}

--- a/src/TournamentManagement/TournamentManagement.Application/Commands/AddEventCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/Commands/AddEventCommand.cs
@@ -3,7 +3,7 @@ using DomainDesign.Common;
 using System;
 using TournamentManagement.Application.Decorators;
 using TournamentManagement.Application.Repository;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 

--- a/src/TournamentManagement/TournamentManagement.Application/Commands/AddTournamentCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/Commands/AddTournamentCommand.cs
@@ -3,7 +3,7 @@ using DomainDesign.Common;
 using System;
 using TournamentManagement.Application.Decorators;
 using TournamentManagement.Application.Repository;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 using TournamentManagement.Domain.VenueAggregate;
 

--- a/src/TournamentManagement/TournamentManagement.Application/Commands/AmendEventCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/Commands/AmendEventCommand.cs
@@ -3,7 +3,7 @@ using DomainDesign.Common;
 using System;
 using TournamentManagement.Application.Decorators;
 using TournamentManagement.Application.Repository;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 

--- a/src/TournamentManagement/TournamentManagement.Application/Commands/AmendTournamentCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/Commands/AmendTournamentCommand.cs
@@ -3,7 +3,7 @@ using DomainDesign.Common;
 using System;
 using TournamentManagement.Application.Decorators;
 using TournamentManagement.Application.Repository;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 using TournamentManagement.Domain.VenueAggregate;
 

--- a/src/TournamentManagement/TournamentManagement.Application/Commands/RemoveEventCommand.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/Commands/RemoveEventCommand.cs
@@ -3,7 +3,7 @@ using DomainDesign.Common;
 using System;
 using TournamentManagement.Application.Decorators;
 using TournamentManagement.Application.Repository;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 
 namespace TournamentManagement.Application.Commands

--- a/src/TournamentManagement/TournamentManagement.Application/Queries/GetEvent.cs
+++ b/src/TournamentManagement/TournamentManagement.Application/Queries/GetEvent.cs
@@ -1,6 +1,7 @@
 ﻿using DomainDesign.Common;
 using System;
 using TournamentManagement.Application.Repository;
+using TournamentManagement.Common;
 using TournamentManagement.Contract;
 using TournamentManagement.Domain.TournamentAggregate;
 

--- a/src/TournamentManagement/TournamentManagement.Application/TournamentManagement.Application.csproj
+++ b/src/TournamentManagement/TournamentManagement.Application/TournamentManagement.Application.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Common\DomainDesign.Common\DomainDesign.Common.csproj" />
+    <ProjectReference Include="..\TournamentManagement.Contract\TournamentManagement.Contract.csproj" />
     <ProjectReference Include="..\TournamentManagement.Domain\TournamentManagement.Domain.csproj" />
   </ItemGroup>
 

--- a/src/TournamentManagement/TournamentManagement.Common/EventType.cs
+++ b/src/TournamentManagement/TournamentManagement.Common/EventType.cs
@@ -1,4 +1,4 @@
-﻿namespace TournamentManagement.Contract
+﻿namespace TournamentManagement.Common
 {
 	public enum EventType
 	{

--- a/src/TournamentManagement/TournamentManagement.Common/Gender.cs
+++ b/src/TournamentManagement/TournamentManagement.Common/Gender.cs
@@ -1,4 +1,4 @@
-﻿namespace TournamentManagement.Contract
+﻿namespace TournamentManagement.Common
 {
 	public enum Gender
 	{

--- a/src/TournamentManagement/TournamentManagement.Common/SetType.cs
+++ b/src/TournamentManagement/TournamentManagement.Common/SetType.cs
@@ -1,4 +1,4 @@
-﻿namespace TournamentManagement.Contract
+﻿namespace TournamentManagement.Common
 {
 	public enum SetType
 	{

--- a/src/TournamentManagement/TournamentManagement.Common/TournamentLevel.cs
+++ b/src/TournamentManagement/TournamentManagement.Common/TournamentLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace TournamentManagement.Contract
+﻿namespace TournamentManagement.Common
 {
 	public enum TournamentLevel
 	{

--- a/src/TournamentManagement/TournamentManagement.Common/TournamentManagement.Common.csproj
+++ b/src/TournamentManagement/TournamentManagement.Common/TournamentManagement.Common.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/TournamentManagement/TournamentManagement.Console/Program.cs
+++ b/src/TournamentManagement/TournamentManagement.Console/Program.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System;
 using System.IO;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Data;
 using TournamentManagement.Data.Repository;
 using TournamentManagement.Domain;

--- a/src/TournamentManagement/TournamentManagement.Console/TournamentManagement.Console.csproj
+++ b/src/TournamentManagement/TournamentManagement.Console/TournamentManagement.Console.csproj
@@ -14,7 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Common\DomainDesign.Common\DomainDesign.Common.csproj" />
     <ProjectReference Include="..\TournamentManagement.Application\TournamentManagement.Application.csproj" />
-    <ProjectReference Include="..\TournamentManagement.Contract\TournamentManagement.Contract.csproj" />
     <ProjectReference Include="..\TournamentManagement.Data\TournamentManagement.Data.csproj" />
     <ProjectReference Include="..\TournamentManagement.Domain\TournamentManagement.Domain.csproj" />
   </ItemGroup>

--- a/src/TournamentManagement/TournamentManagement.Contract/AddEventDto.cs
+++ b/src/TournamentManagement/TournamentManagement.Contract/AddEventDto.cs
@@ -1,4 +1,6 @@
-﻿namespace TournamentManagement.Contract
+﻿using TournamentManagement.Common;
+
+namespace TournamentManagement.Contract
 {
 	public class AddEventDto
 	{

--- a/src/TournamentManagement/TournamentManagement.Contract/AddTournamentDto.cs
+++ b/src/TournamentManagement/TournamentManagement.Contract/AddTournamentDto.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using TournamentManagement.Common;
 
 namespace TournamentManagement.Contract
 {

--- a/src/TournamentManagement/TournamentManagement.Contract/AmendEventDto.cs
+++ b/src/TournamentManagement/TournamentManagement.Contract/AmendEventDto.cs
@@ -1,4 +1,6 @@
-﻿namespace TournamentManagement.Contract
+﻿using TournamentManagement.Common;
+
+namespace TournamentManagement.Contract
 {
 	public class AmendEventDto
 	{

--- a/src/TournamentManagement/TournamentManagement.Contract/AmendTournamentDto.cs
+++ b/src/TournamentManagement/TournamentManagement.Contract/AmendTournamentDto.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using TournamentManagement.Common;
 
 namespace TournamentManagement.Contract
 {

--- a/src/TournamentManagement/TournamentManagement.Contract/TournamentManagement.Contract.csproj
+++ b/src/TournamentManagement/TournamentManagement.Contract/TournamentManagement.Contract.csproj
@@ -4,4 +4,9 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Common\DomainDesign.Common\DomainDesign.Common.csproj" />
+    <ProjectReference Include="..\TournamentManagement.Common\TournamentManagement.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/TournamentManagement/TournamentManagement.Data/Query/GetTournamentSummaryList.cs
+++ b/src/TournamentManagement/TournamentManagement.Data/Query/GetTournamentSummaryList.cs
@@ -4,6 +4,7 @@ using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TournamentManagement.Common;
 using TournamentManagement.Contract;
 using TournamentManagement.Domain.TournamentAggregate;
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/Common/MatchFormatTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/Common/MatchFormatTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using System;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using Xunit;
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CompetitorAggregate/CompetitorTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/CompetitorAggregate/CompetitorTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using System;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.CompetitorAggregate;
 using TournamentManagement.Domain.TournamentAggregate;
 using TournamentManagement.Domain.VenueAggregate;

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/MatchAggregate/MatchScoreTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/MatchAggregate/MatchScoreTests.cs
@@ -1,7 +1,7 @@
 ﻿using FluentAssertions;
 using System;
 using System.Collections.Generic;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.MatchAggregate;
 using Xunit;

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/MatchAggregate/SetWinnerCalculatorTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/MatchAggregate/SetWinnerCalculatorTests.cs
@@ -1,5 +1,5 @@
 ﻿using FluentAssertions;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.MatchAggregate;
 using Xunit;
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/PlayerAggregate/PlayerTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/PlayerAggregate/PlayerTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using System;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using Xunit;
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/RoundAggregate/RoundTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/RoundAggregate/RoundTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using System;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.RoundAggregate;
 using TournamentManagement.Domain.TournamentAggregate;
 using TournamentManagement.Domain.VenueAggregate;

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventEntryTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventEntryTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using System;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate;
 using Xunit;

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventGenderValidatorTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventGenderValidatorTests.cs
@@ -1,5 +1,5 @@
 ﻿using FluentAssertions;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 using Xunit;
 

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using System;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate;

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
@@ -1,7 +1,7 @@
 ﻿using FluentAssertions;
 using System;
 using System.Linq;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate;

--- a/src/TournamentManagement/TournamentManagement.Domain/Common/MatchFormat.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/Common/MatchFormat.cs
@@ -1,7 +1,7 @@
 ﻿using DomainDesign.Common;
 using System;
 using System.Linq;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 
 namespace TournamentManagement.Domain.Common
 {

--- a/src/TournamentManagement/TournamentManagement.Domain/CompetitorAggregate/Competitor.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/CompetitorAggregate/Competitor.cs
@@ -1,6 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using DomainDesign.Common;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 
 namespace TournamentManagement.Domain.CompetitorAggregate

--- a/src/TournamentManagement/TournamentManagement.Domain/MatchAggregate/MatchScore.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/MatchAggregate/MatchScore.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 
 namespace TournamentManagement.Domain.MatchAggregate

--- a/src/TournamentManagement/TournamentManagement.Domain/MatchAggregate/SetWinnerCalculator.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/MatchAggregate/SetWinnerCalculator.cs
@@ -1,4 +1,4 @@
-﻿using TournamentManagement.Contract;
+﻿using TournamentManagement.Common;
 
 namespace TournamentManagement.Domain.MatchAggregate
 {

--- a/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/PlayerAggregate/Player.cs
@@ -1,6 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using DomainDesign.Common;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 
 namespace TournamentManagement.Domain.PlayerAggregate
 {

--- a/src/TournamentManagement/TournamentManagement.Domain/RoundAggregate/Round.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/RoundAggregate/Round.cs
@@ -1,6 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using DomainDesign.Common;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 
 namespace TournamentManagement.Domain.RoundAggregate

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
@@ -2,7 +2,7 @@
 using DomainDesign.Common;
 using System.Collections.Generic;
 using System.Linq;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate.Guards;

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventEntry.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventEntry.cs
@@ -1,7 +1,7 @@
 ﻿using Ardalis.GuardClauses;
 using DomainDesign.Common;
 using System.Collections.Generic;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate.Guards;
 

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventGenderValidator.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/EventGenderValidator.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 
 namespace TournamentManagement.Domain.TournamentAggregate
 {

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Events/TournamentEntryOpened.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Events/TournamentEntryOpened.cs
@@ -1,6 +1,6 @@
 ﻿using DomainDesign.Common;
 using System.Collections.Generic;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 
 namespace TournamentManagement.Domain.TournamentAggregate.Events
 {

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Guards/EventEntryGuards.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Guards/EventEntryGuards.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 
 namespace TournamentManagement.Domain.TournamentAggregate.Guards

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Guards/TournamentGuards.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Guards/TournamentGuards.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.TournamentAggregate;
 
 namespace Ardalis.GuardClauses

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using TournamentManagement.Contract;
+using TournamentManagement.Common;
 using TournamentManagement.Domain.Common;
 using TournamentManagement.Domain.PlayerAggregate;
 using TournamentManagement.Domain.TournamentAggregate.Events;

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentManagement.Domain.csproj
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentManagement.Domain.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Common\DomainDesign.Common\DomainDesign.Common.csproj" />
-    <ProjectReference Include="..\TournamentManagement.Contract\TournamentManagement.Contract.csproj" />
+    <ProjectReference Include="..\TournamentManagement.Common\TournamentManagement.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TournamentManagement/TournamentManagement.WebApi/Controllers/TournamentsController.cs
+++ b/src/TournamentManagement/TournamentManagement.WebApi/Controllers/TournamentsController.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using TournamentManagement.Application;
 using TournamentManagement.Application.Commands;
 using TournamentManagement.Application.Queries;
+using TournamentManagement.Common;
 using TournamentManagement.Contract;
 using TournamentManagement.Data.Query;
 


### PR DESCRIPTION
Move all the common types (in this case Enums) to the Common project, and leave only the DTOs in the contract project