### PR TITLE
Have separate methods singles and doubles event entries

### DIFF
--- a/src/TournamentManagement/TournamentManagement.Console/Program.cs
+++ b/src/TournamentManagement/TournamentManagement.Console/Program.cs
@@ -211,7 +211,7 @@ namespace TournamentManagement.Console
 			tournament.OpenForEntries();
 
 			var player = Player.Register(playerId, "Edward Entered", 12, 123, Gender.Male);
-			tournament.EnterEvent(EventType.MensSingles, player);
+			tournament.EnterSinglesEvent(EventType.MensSingles, player);
 
 			uow.TournamentRepository.Add(tournament);
 
@@ -249,9 +249,9 @@ namespace TournamentManagement.Console
 			var tournament = uow.TournamentRepository.GetById(tournamentId);
 
 			var otherPlayer = Player.Register(new PlayerId(), "Brad New", 123, 121, Gender.Male);
-			tournament.EnterEvent(EventType.WomensSingles, player);
+			tournament.EnterSinglesEvent(EventType.WomensSingles, player);
 			uow.PlayerRepository.Add(otherPlayer);
-			tournament.EnterEvent(EventType.MensSingles, otherPlayer);
+			tournament.EnterSinglesEvent(EventType.MensSingles, otherPlayer);
 
 			uow.SaveChanges();
 		}
@@ -265,7 +265,7 @@ namespace TournamentManagement.Console
 
 			try
 			{
-				tournament.EnterEvent(EventType.MensSingles, Player.Register(playerId, "Someone Else", 1, 1, Gender.Male));
+				tournament.EnterSinglesEvent(EventType.MensSingles, Player.Register(playerId, "Someone Else", 1, 1, Gender.Male));
 			}
 			catch
 			{

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/EventTests.cs
@@ -91,7 +91,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 
-			tennisEvent.EnterEvent(player);
+			tennisEvent.EnterSinglesEvent(player);
 
 			tennisEvent.Entries.Count.Should().Be(1);
 			tennisEvent.Entries[0].PlayerOne.Should().Be(player);
@@ -106,7 +106,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var playerOne = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var playerTwo = Player.Register(new PlayerId(), "Dave", 20, 150, Gender.Male);
 
-			tennisEvent.EnterEvent(playerOne, playerTwo);
+			tennisEvent.EnterDoublesEvent(playerOne, playerTwo);
 
 			tennisEvent.Entries.Count.Should().Be(1);
 			tennisEvent.Entries[0].PlayerOne.Should().Be(playerOne);
@@ -119,7 +119,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var tennisEvent = Event.Create(EventType.MensSingles, new EventSize(128, 32),
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
-			Action act = () => tennisEvent.EnterEvent(null);
+			Action act = () => tennisEvent.EnterSinglesEvent(null);
 
 			act.Should().Throw<ArgumentNullException>()
 				.WithMessage("Value cannot be null. (Parameter 'playerOne')");
@@ -133,12 +133,12 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 
-			Action act = () => tennisEvent.EnterEvent(null, player);
+			Action act = () => tennisEvent.EnterDoublesEvent(null, player);
 
 			act.Should().Throw<ArgumentNullException>()
 				.WithMessage("Value cannot be null. (Parameter 'playerOne')");
 
-			act = () => tennisEvent.EnterEvent(player, null);
+			act = () => tennisEvent.EnterDoublesEvent(player, null);
 
 			act.Should().Throw<ArgumentNullException>()
 				.WithMessage("Value cannot be null. (Parameter 'playerTwo')");
@@ -152,13 +152,13 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male));
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
-			tennisEvent.EnterEvent(player);
+			tennisEvent.EnterSinglesEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male));
+			tennisEvent.EnterSinglesEvent(Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
+			tennisEvent.EnterSinglesEvent(player);
 
 			tennisEvent.Entries.Count.Should().Be(3);
 
-			Action act = () => tennisEvent.EnterEvent(player);
+			Action act = () => tennisEvent.EnterSinglesEvent(player);
 
 			act.Should().Throw<Exception>()
 				.WithMessage("Player Steve has already entered this event");
@@ -172,17 +172,17 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male),
+			tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male),
 				Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "John", 100, 50, Gender.Male),
+			tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "John", 100, 50, Gender.Male),
 				Player.Register(new PlayerId(), "Lee", 100, 50, Gender.Male));
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Barry", 100, 50, Gender.Male), player);
+			tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "Barry", 100, 50, Gender.Male), player);
 
 			tennisEvent.Entries.Count.Should().Be(3);
 
-			Action act = () => tennisEvent.EnterEvent(player,
+			Action act = () => tennisEvent.EnterDoublesEvent(player,
 				Player.Register(new PlayerId(), "Chris", 100, 50, Gender.Male));
 
 			act.Should().Throw<Exception>()
@@ -197,17 +197,17 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male),
+			tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male),
 				Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "John", 100, 50, Gender.Male),
+			tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "John", 100, 50, Gender.Male),
 				Player.Register(new PlayerId(), "Lee", 100, 50, Gender.Male));
 
-			tennisEvent.EnterEvent(player, Player.Register(new PlayerId(), "Barry", 100, 50, Gender.Male));
+			tennisEvent.EnterDoublesEvent(player, Player.Register(new PlayerId(), "Barry", 100, 50, Gender.Male));
 
 			tennisEvent.Entries.Count.Should().Be(3);
 
-			Action act = () => tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Chris", 100, 50, Gender.Male),
+			Action act = () => tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "Chris", 100, 50, Gender.Male),
 				player);
 
 			act.Should().Throw<Exception>()
@@ -222,13 +222,13 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male));
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
-			tennisEvent.EnterEvent(player);
+			tennisEvent.EnterSinglesEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male));
+			tennisEvent.EnterSinglesEvent(Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
+			tennisEvent.EnterSinglesEvent(player);
 
 			tennisEvent.Entries.Count.Should().Be(3);
 
-			tennisEvent.WithdrawFromEvent(player);
+			tennisEvent.WithdrawFromSinglesEvent(player);
 
 			tennisEvent.Entries.Count.Should().Be(2);
 		}
@@ -241,13 +241,13 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var playerOne = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var playerTwo = Player.Register(new PlayerId(), "Dave", 20, 150, Gender.Male);
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "John", 100, 50, Gender.Male),
+			tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "John", 100, 50, Gender.Male),
 				Player.Register(new PlayerId(), "Lee", 100, 50, Gender.Male));
-			tennisEvent.EnterEvent(playerOne, playerTwo);
+			tennisEvent.EnterDoublesEvent(playerOne, playerTwo);
 
 			tennisEvent.Entries.Count.Should().Be(2);
 
-			tennisEvent.WithdrawFromEvent(playerOne, playerTwo);
+			tennisEvent.WithdrawFromDoublesEvent(playerOne, playerTwo);
 
 			tennisEvent.Entries.Count.Should().Be(1);
 		}
@@ -258,7 +258,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var tennisEvent = Event.Create(EventType.MensSingles, new EventSize(128, 32),
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
-			Action act = () => tennisEvent.WithdrawFromEvent(null);
+			Action act = () => tennisEvent.WithdrawFromSinglesEvent(null);
 
 			act.Should().Throw<ArgumentNullException>()
 				.WithMessage("Value cannot be null. (Parameter 'playerOne')");
@@ -270,7 +270,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var tennisEvent = Event.Create(EventType.MensDoubles, new EventSize(128, 32),
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 
-			Action act = () => tennisEvent.WithdrawFromEvent(null, null);
+			Action act = () => tennisEvent.WithdrawFromDoublesEvent(null, null);
 
 			act.Should().Throw<ArgumentNullException>()
 				.WithMessage("Value cannot be null. (Parameter 'playerOne')");
@@ -283,7 +283,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 				MatchFormat.ThreeSetMatchWithFinalSetTieBreak);
 			var playerOne = Player.Register(new PlayerId(), "John", 2, 4, Gender.Male);
 
-			Action act = () => tennisEvent.WithdrawFromEvent(playerOne, null);
+			Action act = () => tennisEvent.WithdrawFromDoublesEvent(playerOne, null);
 
 			act.Should().Throw<ArgumentNullException>()
 				.WithMessage("Value cannot be null. (Parameter 'playerTwo')");
@@ -297,10 +297,10 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 
 			var player = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male));
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
+			tennisEvent.EnterSinglesEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male));
+			tennisEvent.EnterSinglesEvent(Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
 
-			Action act = () => tennisEvent.WithdrawFromEvent(player);
+			Action act = () => tennisEvent.WithdrawFromSinglesEvent(player);
 
 			act.Should().Throw<Exception>()
 				.WithMessage("Player was not entered into the event");
@@ -315,12 +315,12 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var playerOne = Player.Register(new PlayerId(), "Steve", 100, 50, Gender.Male);
 			var playerTwo = Player.Register(new PlayerId(), "Boris", 10, 55, Gender.Male);
 
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male),
+			tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "Dave", 100, 50, Gender.Male),
 				Player.Register(new PlayerId(), "Peter", 100, 50, Gender.Male));
-			tennisEvent.EnterEvent(playerOne, Player.Register(new PlayerId(), "Lee", 100, 50, Gender.Male));
-			tennisEvent.EnterEvent(Player.Register(new PlayerId(), "John", 100, 50, Gender.Male), playerTwo);
+			tennisEvent.EnterDoublesEvent(playerOne, Player.Register(new PlayerId(), "Lee", 100, 50, Gender.Male));
+			tennisEvent.EnterDoublesEvent(Player.Register(new PlayerId(), "John", 100, 50, Gender.Male), playerTwo);
 
-			Action act = () => tennisEvent.WithdrawFromEvent(playerOne, playerTwo);
+			Action act = () => tennisEvent.WithdrawFromDoublesEvent(playerOne, playerTwo);
 
 			act.Should().Throw<Exception>()
 				.WithMessage("Players were not entered into the event");

--- a/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain.UnitTests/TournamentAggregate/TournamentTests.cs
@@ -355,14 +355,26 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		}
 
 		[Fact]
-		public void CannotEnterAnEventIfTournamentIsNotInAcceptingEntriesState()
+		public void CannotEnterSinglesEventIfTournamentIsNotInAcceptingEntriesState()
 		{
 			var tournament = CreateTestTournament();
 			var player = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
 
-			void act() => tournament.EnterEvent(EventType.MensSingles, player);
+			void act() => tournament.EnterSinglesEvent(EventType.MensSingles, player);
 
-			VerifyExceptionThrownWhenNotInCorrectState(act, "EnterEvent", tournament.State);
+			VerifyExceptionThrownWhenNotInCorrectState(act, "EnterSinglesEvent", tournament.State);
+		}
+
+		[Fact]
+		public void CannotEnterDoublesEventIfTournamentIsNotInAcceptingEntriesState()
+		{
+			var tournament = CreateTestTournament();
+			var playerOne = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
+			var playerTwo = Player.Register(new PlayerId(), "Steve Serve", 20, 100, Gender.Male);
+
+			void act() => tournament.EnterDoublesEvent(EventType.MensSingles, playerOne, playerTwo);
+
+			VerifyExceptionThrownWhenNotInCorrectState(act, "EnterDoublesEvent", tournament.State);
 		}
 
 		[Fact]
@@ -371,7 +383,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var tournament = CreateTestTournamentAndOpenForEntries();
 			var player = Player.Register(new PlayerId(), "Paula Player", 10, 200, Gender.Female);
 
-			Action act = () => tournament.EnterEvent(EventType.WomensSingles, player);
+			Action act = () => tournament.EnterSinglesEvent(EventType.WomensSingles, player);
 
 			act.Should().Throw<Exception>()
 				.WithMessage("Tournament does not have an event of type WomensSingles");
@@ -383,7 +395,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var tournament = CreateTestTournamentAndOpenForEntries();
 			var player = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
 
-			tournament.EnterEvent(EventType.MensSingles, player);
+			tournament.EnterSinglesEvent(EventType.MensSingles, player);
 
 			tournament.Events[0].Entries[0].PlayerOne.Name.Should().Be("Peter Player");
 			tournament.Events[0].Entries[0].PlayerTwo.Should().BeNull();
@@ -400,7 +412,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var playerOne = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
 			var playerTwo = Player.Register(new PlayerId(), "Steve Serve", 15, 100, Gender.Male);
 
-			tournament.EnterEvent(EventType.MensDoubles, playerOne, playerTwo);
+			tournament.EnterDoublesEvent(EventType.MensDoubles, playerOne, playerTwo);
 
 			tournament.Events[1].Entries[0].PlayerOne.Name.Should().Be("Peter Player");
 			tournament.Events[1].Entries[0].PlayerTwo.Name.Should().Be("Steve Serve");
@@ -413,10 +425,10 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var playerOne = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
 			var playerTwo = Player.Register(new PlayerId(), "Steve Serve", 15, 100, Gender.Male);
 
-			tournament.EnterEvent(EventType.MensSingles, playerOne);
-			tournament.EnterEvent(EventType.MensSingles, playerTwo);
+			tournament.EnterSinglesEvent(EventType.MensSingles, playerOne);
+			tournament.EnterSinglesEvent(EventType.MensSingles, playerTwo);
 
-			tournament.WithdrawFromEvent(EventType.MensSingles, playerTwo);
+			tournament.WithdrawFromSinglesEvent(EventType.MensSingles, playerTwo);
 
 			tournament.Events[0].Entries.Count.Should().Be(1);
 			tournament.Events[0].Entries.Any(e => e.PlayerOne.Id == playerTwo.Id).Should().BeFalse();
@@ -432,13 +444,13 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var playerOne = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
 			var playerTwo = Player.Register(new PlayerId(), "Steve Serve", 15, 100, Gender.Male);
 
-			tournament.EnterEvent(EventType.MensDoubles,
+			tournament.EnterDoublesEvent(EventType.MensDoubles,
 				Player.Register(new PlayerId(), "John", 10, 200, Gender.Male),
 				Player.Register(new PlayerId(), "John", 11, 201, Gender.Male));
 
-			tournament.EnterEvent(EventType.MensDoubles, playerOne, playerTwo);
+			tournament.EnterDoublesEvent(EventType.MensDoubles, playerOne, playerTwo);
 
-			tournament.WithdrawFromEvent(EventType.MensDoubles, playerOne, playerTwo);
+			tournament.WithdrawFromDoublesEvent(EventType.MensDoubles, playerOne, playerTwo);
 
 			tournament.Events[0].Entries.Count.Should().Be(1);
 			tournament.Events[0].Entries
@@ -447,16 +459,30 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 		}
 
 		[Fact]
-		public void CannotWithdrawPlayersIfTournamentIsNotInOpenForEntriesState()
+		public void CannotWithdrawSinglesPlayerIfTournamentIsNotInOpenForEntriesState()
 		{
 			var tournament = CreateTestTournament();
 			AddEventToTournament(tournament, EventType.MensSingles);
 			var player = Player.Register(new PlayerId(), "Steve Serve", 1, 1, Gender.Male);
 
-			Action act = () => tournament.WithdrawFromEvent(EventType.MensSingles, player);
+			Action act = () => tournament.WithdrawFromSinglesEvent(EventType.MensSingles, player);
 
 			act.Should().Throw<Exception>()
-				.WithMessage("Action WithdrawFromEvent not allowed for a tournament in the state BeingDefined");
+				.WithMessage("Action WithdrawFromSinglesEvent not allowed for a tournament in the state BeingDefined");
+		}
+
+		[Fact]
+		public void CannotWithdrawDoublePlayersIfTournamentIsNotInOpenForEntriesState()
+		{
+			var tournament = CreateTestTournament();
+			AddEventToTournament(tournament, EventType.MensSingles);
+			var playerOne = Player.Register(new PlayerId(), "Steve Serve", 1, 1, Gender.Male);
+			var playerTwo = Player.Register(new PlayerId(), "Peter Player", 10, 200, Gender.Male);
+
+			Action act = () => tournament.WithdrawFromDoublesEvent(EventType.MensSingles, playerOne, playerTwo);
+
+			act.Should().Throw<Exception>()
+				.WithMessage("Action WithdrawFromDoublesEvent not allowed for a tournament in the state BeingDefined");
 		}
 
 		[Fact]
@@ -465,7 +491,7 @@ namespace TournamentManagement.Domain.UnitTests.TournamentAggregate
 			var tournament = CreateTestTournamentAndOpenForEntries();
 			var player = Player.Register(new PlayerId(), "Steve Serve", 1, 1, Gender.Male);
 
-			Action act = () => tournament.WithdrawFromEvent(EventType.WomensSingles, player);
+			Action act = () => tournament.WithdrawFromSinglesEvent(EventType.WomensSingles, player);
 
 			act.Should().Throw<Exception>()
 				.WithMessage("Tournament does not have an event of type WomensSingles");

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Event.cs
@@ -52,53 +52,53 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			IsCompleted = true;
 		}
 
-		internal void EnterEvent(Player playerOne, Player playerTwo = null)
+		internal void EnterSinglesEvent(Player playerOne)
 		{
-			EventEntry entry;
+			Guard.Against.NotASinglesEventType(EventType);
+			Guard.Against.Null(playerOne, nameof(playerOne));
+			Guard.Against.PlayerAlreadyEnteredInSingleEvent(Entries, playerOne);
 
-			if (SinglesEvent)
-			{
-				Guard.Against.Null(playerOne, nameof(playerOne));
-				Guard.Against.PlayerAlreadyEnteredInSingleEvent(Entries, playerOne);
-
-				entry = EventEntry.CreateSinglesEventEntry(EventType, playerOne);
-			}
-			else
-			{
-				Guard.Against.Null(playerOne, nameof(playerOne));
-				Guard.Against.Null(playerTwo, nameof(playerTwo));
-				Guard.Against.PlayersAlreadyEnteredInDoublesEvent(Entries, playerOne, playerTwo);
-
-				entry = EventEntry.CreateDoublesEventEntry(EventType, playerOne, playerTwo);
-			}
+			var entry = EventEntry.CreateSinglesEventEntry(EventType, playerOne);
 			
 			_entries.Add(entry);
 		}
 
-		internal void WithdrawFromEvent(Player playerOne, Player playerTwo = null)
+		internal void EnterDoublesEvent(Player playerOne, Player playerTwo)
 		{
-			if (SinglesEvent)
-			{
-				Guard.Against.Null(playerOne, nameof(playerOne));
-				var entry = Guard.Against.PlayerNotEnteredInSingleEvent(Entries, playerOne);
+			Guard.Against.NotADoublesEventType(EventType);
+			Guard.Against.Null(playerOne, nameof(playerOne));
+			Guard.Against.Null(playerTwo, nameof(playerTwo));
+			Guard.Against.PlayersAlreadyEnteredInDoublesEvent(Entries, playerOne, playerTwo);
 
-				_entries.Remove(entry);
-			}
-			else
-			{
-				Guard.Against.Null(playerOne, nameof(playerOne));
-				Guard.Against.Null(playerTwo, nameof(playerTwo));
-				var entry = Guard.Against.PlayersNotEnteredInDoublesEvent(Entries, playerOne, playerTwo);
+			var entry = EventEntry.CreateDoublesEventEntry(EventType, playerOne, playerTwo);
 
-				_entries.Remove(entry);
-			}
+			_entries.Add(entry);
+		}
+
+		internal void WithdrawFromSinglesEvent(Player playerOne)
+		{
+			Guard.Against.NotASinglesEventType(EventType);
+			Guard.Against.Null(playerOne, nameof(playerOne));
+
+			var entry = Guard.Against.PlayerNotEnteredInSingleEvent(Entries, playerOne);
+
+			_entries.Remove(entry);
+		}
+
+		internal void WithdrawFromDoublesEvent(Player playerOne, Player playerTwo)
+		{
+			Guard.Against.NotADoublesEventType(EventType);
+			Guard.Against.Null(playerOne, nameof(playerOne));
+			Guard.Against.Null(playerTwo, nameof(playerTwo));
+			var entry = Guard.Against.PlayersNotEnteredInDoublesEvent(Entries, playerOne, playerTwo);
+
+			_entries.Remove(entry);
 		}
 
 		private void SetAttributeDetails(EventSize eventSize, MatchFormat matchFormat)
 		{
 			EventSize = eventSize;
 			MatchFormat = matchFormat;
-			
 		}
 	}
 }

--- a/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
+++ b/src/TournamentManagement/TournamentManagement.Domain/TournamentAggregate/Tournament.cs
@@ -118,20 +118,40 @@ namespace TournamentManagement.Domain.TournamentAggregate
 			RaiseDomainEvent(new TournamentEntryOpened(Id, _events.Select(e => e.EventType)));
 		}
 
-		public void EnterEvent(EventType eventType, Player playerOne, Player playerTwo = null)
+		public void EnterSinglesEvent(EventType eventType, Player playerOne)
 		{
-			Guard.Against.TournamentActionInWrongState(TournamentState.AcceptingEntries, State, nameof(EnterEvent));
+			Guard.Against.TournamentActionInWrongState(TournamentState.AcceptingEntries, State,
+				nameof(EnterSinglesEvent));
 			var tennisEvent = Guard.Against.MissingEventType(_events, eventType);
 
-			tennisEvent.EnterEvent(playerOne, playerTwo);
+			tennisEvent.EnterSinglesEvent(playerOne);
 		}
 
-		public void WithdrawFromEvent(EventType eventType, Player playerOne, Player playerTwo = null)
+		public void EnterDoublesEvent(EventType eventType, Player playerOne, Player playerTwo)
 		{
-			Guard.Against.TournamentActionInWrongState(TournamentState.AcceptingEntries, State, nameof(WithdrawFromEvent));
+			Guard.Against.TournamentActionInWrongState(TournamentState.AcceptingEntries, State,
+				nameof(EnterDoublesEvent));
 			var tennisEvent = Guard.Against.MissingEventType(_events, eventType);
 
-			tennisEvent.WithdrawFromEvent(playerOne, playerTwo);
+			tennisEvent.EnterDoublesEvent(playerOne, playerTwo);
+		}
+
+		public void WithdrawFromSinglesEvent(EventType eventType, Player playerOne)
+		{
+			Guard.Against.TournamentActionInWrongState(TournamentState.AcceptingEntries, State,
+				nameof(WithdrawFromSinglesEvent));
+			var tennisEvent = Guard.Against.MissingEventType(_events, eventType);
+
+			tennisEvent.WithdrawFromSinglesEvent(playerOne);
+		}
+
+		public void WithdrawFromDoublesEvent(EventType eventType, Player playerOne, Player playerTwo)
+		{
+			Guard.Against.TournamentActionInWrongState(TournamentState.AcceptingEntries, State,
+				nameof(WithdrawFromDoublesEvent));
+			var tennisEvent = Guard.Against.MissingEventType(_events, eventType);
+
+			tennisEvent.WithdrawFromDoublesEvent(playerOne, playerTwo);
 		}
 
 		public void CloseEntries()


### PR DESCRIPTION
In the domain model, rather than having a single method for entering an event, have separate method for entering a singles event (specifying 1 player) and entering a doubles event (specifying 2 players)

Ditto for withdrawing from an event